### PR TITLE
Refactor music player

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ image = { version = "0.24", features = ["ico", "png"] }
 reqwest = { version = "0.11", features = ["blocking", "multipart", "json"] }
 suppaftp = "6.0"
 cpal = "0.15"
+md5 = "0.7"
 
 # Windows-specific dependencies
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -909,7 +909,10 @@ impl Application for Ultimate64Browser {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        self.video_streaming.subscription().map(Message::Streaming)
+        Subscription::batch([
+            self.video_streaming.subscription().map(Message::Streaming),
+            self.music_player.subscription().map(Message::MusicPlayer),
+        ])
     }
 }
 
@@ -1114,11 +1117,11 @@ impl Ultimate64Browser {
             text("CONNECTION STATUS").size(18),
             Space::with_height(10),
             if self.status.connected {
-                text(format!("✓ Connected to {}", self.settings.connection.host)).style(
+                text(format!("Connected to {}", self.settings.connection.host)).style(
                     iced::theme::Text::Color(iced::Color::from_rgb(0.2, 0.8, 0.2)),
                 )
             } else {
-                text("✗ Not connected").style(iced::theme::Text::Color(iced::Color::from_rgb(
+                text("Not connected").style(iced::theme::Text::Color(iced::Color::from_rgb(
                     0.8, 0.2, 0.2,
                 )))
             },


### PR DESCRIPTION
- Timer now properly progresses (added subscription to main.rs)
- Song length database parsing handles milliseconds format (2:53.935)
- Database subsong count is authoritative over SID header
- Per-subsong duration lookup from database
- Stop button resets Commodore to silence SID hardware
- Removed UTF-8 icons causing display issues
- Fixed scrollbar hiding buttons (proper padding)