### PR TITLE
Add video scaling modes: Scale2x and Scanlines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // Remove the windows_subsystem attribute during development to see console output
 // Uncomment for release builds:
-// #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 use iced::{
     Application, Command, Element, Length, Settings, Subscription, Theme, executor,


### PR DESCRIPTION
Adds three scaling options for the video stream display:

- Nearest - Fast 2x nearest-neighbor scaling (default)
- Scale2x - Pixel art upscaling algorithm that smooths diagonal edges while preserving sharp details
- Scanlines - CRT-style effect with alternating darkened lines for authentic retro look

Scaling mode selector added to the stream controls panel. Scaled output stored separately from raw frame buffer to preserve original resolution for screenshots.
