### PR TITLE
Add separate starting directories for File Browser and Music Player tabs

### DIFF
--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -79,17 +79,23 @@ pub struct FileBrowser {
 }
 
 impl FileBrowser {
-    pub fn new() -> Self {
-        let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    /// Create a new FileBrowser with an optional starting directory.
+    /// If start_dir is None or invalid, defaults to the user's home directory.
+    pub fn new(start_dir: Option<PathBuf>) -> Self {
+        // Use provided path if it exists and is a directory, otherwise fall back to home
+        let initial_dir = start_dir
+            .filter(|p| p.exists() && p.is_dir())
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
+
         let mut browser = Self {
-            current_directory: home_dir.clone(),
+            current_directory: initial_dir.clone(),
             files: Vec::new(),
             selected_file: None,
             checked_files: HashSet::new(),
             selected_drive: DriveOption::A,
             status_message: None,
         };
-        browser.load_directory(&home_dir);
+        browser.load_directory(&initial_dir);
         browser
     }
 

--- a/src/music_player.rs
+++ b/src/music_player.rs
@@ -167,11 +167,16 @@ pub struct MusicPlayer {
 }
 
 impl MusicPlayer {
-    pub fn new() -> Self {
-        let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    /// Create a new MusicPlayer with an optional starting directory.
+    /// If start_dir is None or invalid, defaults to the user's home directory.
+    pub fn new(start_dir: Option<PathBuf>) -> Self {
+        // Use provided path if it exists and is a directory, otherwise fall back to home
+        let initial_dir = start_dir
+            .filter(|p| p.exists() && p.is_dir())
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
 
         let mut player = Self {
-            browser_directory: home_dir.clone(),
+            browser_directory: initial_dir.clone(),
             browser_entries: Vec::new(),
             browser_selected: None,
 
@@ -198,7 +203,7 @@ impl MusicPlayer {
             status_message: "Ready".to_string(),
         };
 
-        player.load_browser_entries(&home_dir);
+        player.load_browser_entries(&initial_dir);
 
         // Try to auto-load song lengths database from config directory
         if let Some(config_dir) = dirs::config_dir() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -20,6 +20,12 @@ pub struct DefaultPaths {
     pub disk_images: Option<PathBuf>,
     pub music_files: Option<PathBuf>,
     pub programs: Option<PathBuf>,
+    /// Starting directory for the File Browser tab
+    #[serde(default)]
+    pub file_browser_start_dir: Option<PathBuf>,
+    /// Starting directory for the Music Player tab
+    #[serde(default)]
+    pub music_player_start_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,6 +52,8 @@ impl Default for AppSettings {
                 disk_images: None,
                 music_files: None,
                 programs: None,
+                file_browser_start_dir: None,
+                music_player_start_dir: None,
             },
             preferences: Preferences {
                 auto_mount_and_run: false,

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -264,9 +264,7 @@ impl VideoStreaming {
                 self.audio_enabled = enabled;
                 Command::none()
             }
-            StreamingMessage::ToggleFullscreen => {
-                Command::none()
-            }
+            StreamingMessage::ToggleFullscreen => Command::none(),
             StreamingMessage::VideoClicked => {
                 // Check for double-click (within 300ms)
                 let now = std::time::Instant::now();


### PR DESCRIPTION
Adds two new settings to configure independent starting directories:

- File Browser tab: for disk images and programs
- Music Player tab: for music files

