### PR TITLE
ZIP extraction improvements & latest releases ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5500,7 +5500,7 @@ dependencies = [
 
 [[package]]
 name = "ultimate64-manager"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "cpal",

--- a/src/csdb.rs
+++ b/src/csdb.rs
@@ -26,6 +26,9 @@ use zip::ZipArchive;
 /// Default delay between requests in milliseconds (1.5 seconds)
 const REQUEST_DELAY_MS: u64 = 1500;
 
+/// Maximum ZIP file size for extraction (100 MB).
+pub const MAX_ZIP_EXTRACT_BYTES: u64 = 100 * 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SearchCategory {
     #[default]
@@ -901,21 +904,22 @@ impl Default for CsdbClient {
 // ZIP extraction functions
 // -----------------------------------------------------------------------------
 
-/// Extract a ZIP file from bytes to a temporary directory
-pub fn extract_zip(zip_data: &[u8], source_filename: &str) -> Result<ExtractedZip> {
+/// Extract a ZIP file from bytes to a **specific** target directory.
+///
+/// This is the preferred function when you want the files to land in a known
+/// location (e.g., the CSDB downloads folder).  The directory is created if it
+/// does not exist.  Hidden files and macOS `__MACOSX` metadata entries are
+/// always skipped.  Path components inside the archive are stripped so every
+/// file ends up directly inside `target_dir`.
+pub fn extract_zip_to_dir(
+    zip_data: &[u8],
+    source_filename: &str,
+    target_dir: &std::path::Path,
+) -> Result<ExtractedZip> {
     let reader = Cursor::new(zip_data);
     let mut archive = ZipArchive::new(reader).context("Failed to open ZIP archive")?;
 
-    // Create temp directory for extraction with unique name
-    let temp_dir = std::env::temp_dir().join(format!(
-        "csdb_extract_{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-    ));
-
-    std::fs::create_dir_all(&temp_dir).context("Failed to create temp directory")?;
+    std::fs::create_dir_all(target_dir).context("Failed to create target directory")?;
 
     let mut files = Vec::new();
 
@@ -937,13 +941,13 @@ pub fn extract_zip(zip_data: &[u8], source_filename: &str) -> Result<ExtractedZi
             continue;
         }
 
-        // Extract just the filename (strip path)
+        // Extract just the filename (strip path components)
         let clean_filename = filename.rsplit('/').next().unwrap_or(&filename).to_string();
         if clean_filename.is_empty() || clean_filename.starts_with('.') {
             continue;
         }
 
-        let out_path = temp_dir.join(&clean_filename);
+        let out_path = target_dir.join(&clean_filename);
 
         let mut contents = Vec::new();
         file.read_to_end(&mut contents)
@@ -972,7 +976,7 @@ pub fn extract_zip(zip_data: &[u8], source_filename: &str) -> Result<ExtractedZi
 
     Ok(ExtractedZip {
         source_filename: source_filename.to_string(),
-        extract_dir: temp_dir,
+        extract_dir: target_dir.to_path_buf(),
         files,
     })
 }

--- a/src/csdb_browser.rs
+++ b/src/csdb_browser.rs
@@ -21,7 +21,7 @@ use ultimate64::Rest;
 
 use crate::csdb::{
     CsdbClient, ExtractedZip, LatestRelease, ReleaseDetails, ReleaseFile, SearchCategory,
-    SearchResult, TopListCategory, TopListEntry, extract_zip, get_runnable_extracted_files,
+    SearchResult, TopListCategory, TopListEntry, extract_zip_to_dir, get_runnable_extracted_files,
     get_runnable_files, is_zip_file,
 };
 
@@ -350,8 +350,10 @@ impl CsdbBrowser {
             CsdbBrowserMessage::LatestLoaded(result) => {
                 self.is_loading = false;
                 match result {
-                    Ok(releases) => {
+                    Ok(mut releases) => {
                         let count = releases.len();
+                        // Reverse so newest releases appear at the top of the list
+                        releases.reverse();
                         self.latest_releases = releases;
                         self.view_state = ViewState::LatestReleases;
                         self.status_message = Some(format!("Loaded {} release(s)", count));
@@ -754,6 +756,22 @@ impl CsdbBrowser {
 
                         let file = file.clone();
 
+                        // Build target directory: CSDB/<release_type>/<zip_stem>/
+                        // This keeps extracted files organised in the CSDB downloads folder
+                        // alongside any separately downloaded ZIPs.
+                        let release_type_dir = release
+                            .release_type
+                            .as_deref()
+                            .map(|t| sanitize_dirname(t))
+                            .unwrap_or_else(|| "Other".to_string());
+                        let zip_stem = std::path::Path::new(&file.filename)
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .map(|s| sanitize_dirname(s))
+                            .unwrap_or_else(|| "extracted".to_string());
+                        let extract_target =
+                            self.download_dir.join(&release_type_dir).join(&zip_stem);
+
                         return Task::perform(
                             async move {
                                 // Download the ZIP file
@@ -767,9 +785,10 @@ impl CsdbBrowser {
                                 .map_err(|_| "Download timed out".to_string())?
                                 .map_err(|e| e.to_string())?;
 
-                                // Extract the ZIP (blocking operation)
+                                // Extract the ZIP to the CSDB folder (blocking operation)
                                 tokio::task::spawn_blocking(move || {
-                                    extract_zip(&data, &filename).map_err(|e| e.to_string())
+                                    extract_zip_to_dir(&data, &filename, &extract_target)
+                                        .map_err(|e| e.to_string())
                                 })
                                 .await
                                 .map_err(|e| format!("Task error: {}", e))?

--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use ultimate64::{Rest, drives::MountMode};
 
+use crate::csdb::{MAX_ZIP_EXTRACT_BYTES, extract_zip_to_dir};
 use crate::dir_preview::{self, ContentPreview};
 use crate::disk_image::{self, DiskInfo, FileType};
 use crate::pdf_preview;
@@ -40,6 +41,9 @@ pub enum FileBrowserMessage {
     NavigateToPath(PathBuf),
     FilterChanged(String),
     NavigateToCsdbDir,
+    // ZIP extraction: extract archive to a sibling subfolder then navigate there
+    ExtractZip(PathBuf),
+    ZipExtracted(Result<PathBuf, String>),
     // Disk info popup
     ShowDiskInfo(PathBuf),
     DiskInfoLoaded(Result<DiskInfo, String>),
@@ -96,6 +100,8 @@ pub struct FileBrowser {
     selected_drive: DriveOption,
     status_message: Option<String>,
     filter: String,
+    // True while an async operation (e.g. ZIP extraction) is in progress
+    is_loading: bool,
     // Disk info popup state
     disk_info_popup: Option<DiskInfo>,
     disk_info_path: Option<PathBuf>,
@@ -123,6 +129,7 @@ impl FileBrowser {
             selected_drive: DriveOption::A,
             status_message: None,
             filter: String::new(),
+            is_loading: false,
             disk_info_popup: None,
             disk_info_path: None,
             disk_info_loading: false,
@@ -318,6 +325,71 @@ impl FileBrowser {
                 }
                 Task::none()
             }
+            // Extract a ZIP archive into a sibling subfolder (named after the ZIP stem),
+            // then navigate into that folder so the contents are immediately visible.
+            FileBrowserMessage::ExtractZip(zip_path) => {
+                // Reject files above the size limit to avoid accidentally unpacking
+                // massive TOSEC collections or similar large ZIPs
+                match std::fs::metadata(&zip_path) {
+                    Ok(meta) if meta.len() > MAX_ZIP_EXTRACT_BYTES => {
+                        self.status_message = Some(format!(
+                            "ZIP too large ({:.1} MB). Maximum allowed is {} MB.",
+                            meta.len() as f64 / (1024.0 * 1024.0),
+                            MAX_ZIP_EXTRACT_BYTES / (1024 * 1024)
+                        ));
+                        return Task::none();
+                    }
+                    Err(e) => {
+                        self.status_message = Some(format!("Cannot read ZIP metadata: {}", e));
+                        return Task::none();
+                    }
+                    _ => {}
+                }
+
+                // Target dir = same parent as the ZIP, subfolder named after the ZIP stem
+                let zip_stem = zip_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("extracted")
+                    .to_string();
+                let target_dir = match zip_path.parent() {
+                    Some(parent) => parent.join(&zip_stem),
+                    None => {
+                        self.status_message = Some("Cannot determine parent directory".to_string());
+                        return Task::none();
+                    }
+                };
+
+                let zip_name = zip_path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("archive.zip")
+                    .to_string();
+
+                self.is_loading = true;
+                self.status_message = Some(format!("Extracting {}...", zip_name));
+
+                Task::perform(
+                    extract_zip_file_async(zip_path, target_dir),
+                    FileBrowserMessage::ZipExtracted,
+                )
+            }
+            FileBrowserMessage::ZipExtracted(result) => {
+                self.is_loading = false;
+                match result {
+                    Ok(dir) => {
+                        self.status_message = Some(format!("Extracted to: {}", dir.display()));
+                        // Navigate into the freshly extracted folder
+                        self.load_directory(&dir);
+                        self.current_directory = dir;
+                        self.checked_files.clear();
+                    }
+                    Err(e) => {
+                        self.status_message = Some(format!("Extraction failed: {}", e));
+                    }
+                }
+                Task::none()
+            }
             // Disk info popup messages
             FileBrowserMessage::ShowDiskInfo(path) => {
                 self.disk_info_loading = true;
@@ -492,7 +564,7 @@ impl FileBrowser {
         };
 
         // Status message
-        let status = if self.disk_info_loading || self.content_preview_loading {
+        let status = if self.disk_info_loading || self.content_preview_loading || self.is_loading {
             text("Loading...").size(small)
         } else if let Some(msg) = &self.status_message {
             text(msg).size(small)
@@ -827,6 +899,7 @@ impl FileBrowser {
                 Some("txt") | Some("atxt") | Some("nfo") | Some("diz") => "TXT",
                 Some("png") | Some("jpg") | Some("jpeg") | Some("gif") | Some("bmp") => "IMG",
                 Some("pdf") => "PDF",
+                Some("zip") => "ZIP",
                 _ => "",
             }
         };
@@ -945,6 +1018,23 @@ impl FileBrowser {
                 )
                 .style(container::bordered_box)
                 .into(),
+                Some("zip") => {
+                    // Extract the ZIP into a sibling subdirectory, then navigate there.
+                    // Very large ZIPs (TOSEC etc.) are rejected with a clear error message.
+                    tooltip(
+                        button(text("Extract").size(small))
+                            .on_press(FileBrowserMessage::ExtractZip(entry.path.clone()))
+                            .padding([2, 8]),
+                        text(format!(
+                            "Extract ZIP to subfolder (max {} MB)",
+                            MAX_ZIP_EXTRACT_BYTES / (1024 * 1024)
+                        ))
+                        .size(normal),
+                        tooltip::Position::Top,
+                    )
+                    .style(container::bordered_box)
+                    .into()
+                }
                 _ => {
                     // Check for text, image, or PDF preview
                     if is_text_file {
@@ -1079,6 +1169,8 @@ impl FileBrowser {
                                     | Some("mod")
                                     | Some("tap")
                                     | Some("t64")
+                                    // ZIP archives (extract-to-subdir action)
+                                    | Some("zip")
                                     // Text files for readme preview
                                     | Some("txt")
                                     | Some("atxt")
@@ -1127,6 +1219,32 @@ async fn load_disk_info_async(path: PathBuf) -> Result<DiskInfo, String> {
     tokio::task::spawn_blocking(move || disk_image::read_disk_info(&path))
         .await
         .map_err(|e| format!("Task error: {}", e))?
+}
+
+/// Read a ZIP from disk, extract it to `target_dir`, and return the target dir
+/// path on success.  The actual extraction runs on a blocking thread so the
+/// async runtime is not stalled.
+async fn extract_zip_file_async(zip_path: PathBuf, target_dir: PathBuf) -> Result<PathBuf, String> {
+    // Read the ZIP bytes from disk
+    let data = tokio::fs::read(&zip_path)
+        .await
+        .map_err(|e| format!("Failed to read ZIP file: {}", e))?;
+
+    let filename = zip_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("archive.zip")
+        .to_string();
+
+    let target_dir_clone = target_dir.clone();
+    // Run the CPU-bound extraction off the async thread pool
+    tokio::task::spawn_blocking(move || {
+        extract_zip_to_dir(&data, &filename, &target_dir_clone)
+            .map(|_| target_dir_clone)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("Task error: {}", e))?
 }
 
 async fn load_content_preview_async(path: PathBuf) -> Result<ContentPreview, String> {


### PR DESCRIPTION
 ZIP files now extract to CSDB/<release_type>/<zip_stem>/ instead of a throwaway temp folder, so extracted files are visible in the File Browser tab alongside other downloads. ZIP files are now shown in the file list with an Extract button. Clicking it extracts the archive into a sibling subfolder and navigates there automatically.