### PR TITLE
Add raw TCP port-64 client, live hardware monitor, and extended memor…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,13 @@ mod mod_info;
 mod music_player;
 mod pdf_preview;
 mod petscii;
+mod port64;
 mod profiles;
 mod remote_browser;
 mod screenshot_api;
 mod settings;
 mod sid_info;
+mod sid_monitor;
 mod stream_control;
 mod streaming;
 mod templates;
@@ -51,6 +53,7 @@ use music_player::{MusicPlayer, MusicPlayerMessage, PlaybackState};
 use profiles::ProfileManager;
 use remote_browser::{RemoteBrowser, RemoteBrowserMessage};
 use settings::{AppSettings, ConnectionSettings, StreamControlMethod};
+use sid_monitor::{SidMonitor, SidMonitorMessage};
 use streaming::{StreamingMessage, VideoStreaming};
 use templates::{DiskTemplate, TemplateManager};
 
@@ -172,6 +175,8 @@ pub enum Message {
 
     // Memory Editor
     MemoryEditor(MemoryEditorMessage),
+    // Hardware monitor (SID / VIC-II / CIA)
+    Monitor(SidMonitorMessage),
     // Machine control
     ResetMachine,
     RebootMachine,
@@ -222,6 +227,7 @@ pub enum Tab {
     MusicPlayer,
     VideoViewer,
     MemoryEditor,
+    Monitor,
     Configuration,
     CsdbBrowser,
     Settings,
@@ -234,6 +240,7 @@ impl std::fmt::Display for Tab {
             Tab::MusicPlayer => write!(f, "Music Player"),
             Tab::VideoViewer => write!(f, "Video Viewer"),
             Tab::MemoryEditor => write!(f, "Memory Editor"),
+            Tab::Monitor => write!(f, "HW Monitor"),
             Tab::Configuration => write!(f, "Configuration"),
             Tab::CsdbBrowser => write!(f, "CSDb"),
             Tab::Settings => write!(f, "Settings"),
@@ -270,6 +277,7 @@ pub struct Ultimate64Browser {
 
     music_player: MusicPlayer,
     memory_editor: MemoryEditor,
+    sid_monitor: SidMonitor,
     config_editor: ConfigEditor,
     settings: AppSettings,
     template_manager: TemplateManager,
@@ -338,6 +346,7 @@ impl Ultimate64Browser {
             active_pane: Pane::Left,
             music_player,
             memory_editor: MemoryEditor::new(),
+            sid_monitor: SidMonitor::new(),
             config_editor: ConfigEditor::new(),
             host_input: settings.connection.host.clone(),
             password_input: settings.connection.password.clone().unwrap_or_default(),
@@ -523,8 +532,17 @@ impl Ultimate64Browser {
             }
             Message::MemoryEditor(msg) => self
                 .memory_editor
-                .update(msg, self.connection.clone())
+                .update(
+                    msg,
+                    self.connection.clone(),
+                    Some(self.settings.connection.host.clone()),
+                    self.settings.connection.password.clone(),
+                )
                 .map(Message::MemoryEditor),
+            Message::Monitor(msg) => self
+                .sid_monitor
+                .update(msg, self.connection.clone())
+                .map(Message::Monitor),
             Message::LeftBrowser(msg) => {
                 // Check if this is a "run" operation that should stop music
                 let should_stop_music = matches!(
@@ -1782,6 +1800,7 @@ impl Ultimate64Browser {
                 self.tab_button("MUSIC PLAYER", Tab::MusicPlayer),
                 self.tab_button("VIDEO VIEWER", Tab::VideoViewer),
                 self.tab_button("MEMORY", Tab::MemoryEditor),
+                self.tab_button("MONITOR", Tab::Monitor),
                 self.tab_button("CONFIG", Tab::Configuration),
                 self.tab_button("CSDB", Tab::CsdbBrowser),
                 self.tab_button("SETTINGS", Tab::Settings),
@@ -1824,6 +1843,10 @@ impl Ultimate64Browser {
                 .memory_editor
                 .view(self.status.connected, self.settings.preferences.font_size)
                 .map(Message::MemoryEditor),
+            Tab::Monitor => self
+                .sid_monitor
+                .view(self.status.connected, self.settings.preferences.font_size)
+                .map(Message::Monitor),
             Tab::Configuration => self
                 .config_editor
                 .view(self.status.connected, self.settings.preferences.font_size)
@@ -1875,6 +1898,21 @@ impl Ultimate64Browser {
                     Key::Character(ref c) if c.as_str() == "f" && modifiers.alt() => Some(
                         Message::Streaming(streaming::StreamingMessage::ToggleFullscreen),
                     ),
+                    // Cmd/Ctrl+Z = Undo, Cmd/Ctrl+Shift+Z = Redo in Memory Editor
+                    Key::Character(ref c)
+                        if c.as_str() == "z" && modifiers.command() && !modifiers.shift() =>
+                    {
+                        Some(Message::MemoryEditor(
+                            memory_editor::MemoryEditorMessage::Undo,
+                        ))
+                    }
+                    Key::Character(ref c)
+                        if c.as_str() == "z" && modifiers.command() && modifiers.shift() =>
+                    {
+                        Some(Message::MemoryEditor(
+                            memory_editor::MemoryEditorMessage::Redo,
+                        ))
+                    }
                     _ => None,
                 }
             } else {
@@ -1904,6 +1942,8 @@ impl Ultimate64Browser {
             self.remote_browser
                 .subscription()
                 .map(Message::RemoteBrowser),
+            self.memory_editor.subscription().map(Message::MemoryEditor),
+            self.sid_monitor.subscription().map(Message::Monitor),
             keyboard_sub,
             window_events,
             status_check,

--- a/src/memory_editor.rs
+++ b/src/memory_editor.rs
@@ -1,5 +1,5 @@
 use iced::{
-    Element, Length, Task,
+    Element, Length, Subscription, Task,
     widget::{
         Column, Row, Space, button, column, container, pick_list, row, rule, scrollable, text,
         text_input, tooltip,
@@ -9,10 +9,18 @@ use std::sync::Arc;
 use tokio::sync::Mutex as TokioMutex;
 use ultimate64::Rest;
 
+use crate::port64;
+
 /// Timeout for REST API operations
 const REST_TIMEOUT_SECS: u64 = 5;
 
-/// Predefined C64 memory locations
+/// Maximum bytes per REST write chunk (mirrors the C++ SOCKET_BUFFER_SIZE guard).
+const RAW_CHUNK: usize = 256;
+
+// ─────────────────────────────────────────────────────────────────
+//  Memory locations
+// ─────────────────────────────────────────────────────────────────
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryLocation {
     pub name: &'static str,
@@ -27,95 +35,218 @@ impl std::fmt::Display for MemoryLocation {
     }
 }
 
-/// Common C64 memory locations
 pub const MEMORY_LOCATIONS: &[MemoryLocation] = &[
-    MemoryLocation {
-        name: "Screen Memory",
-        address: 0x0400,
-        length: 0x400,
-        description: "Default screen RAM",
-    },
-    MemoryLocation {
-        name: "Color RAM",
-        address: 0xD800,
-        length: 0x400,
-        description: "Screen color attributes",
-    },
-    MemoryLocation {
-        name: "Sprite Pointers",
-        address: 0x07F8,
-        length: 0x08,
-        description: "Sprite data pointers",
-    },
-    MemoryLocation {
-        name: "VIC-II Registers",
-        address: 0xD000,
-        length: 0x40,
-        description: "Video controller",
-    },
-    MemoryLocation {
-        name: "SID Registers",
-        address: 0xD400,
-        length: 0x20,
-        description: "Sound synthesizer",
-    },
-    MemoryLocation {
-        name: "CIA #1",
-        address: 0xDC00,
-        length: 0x10,
-        description: "Keyboard/joystick",
-    },
-    MemoryLocation {
-        name: "CIA #2",
-        address: 0xDD00,
-        length: 0x10,
-        description: "Serial/parallel",
-    },
-    MemoryLocation {
-        name: "Kernal ROM",
-        address: 0xE000,
-        length: 0x2000,
-        description: "System ROM",
-    },
-    MemoryLocation {
-        name: "BASIC ROM",
-        address: 0xA000,
-        length: 0x2000,
-        description: "BASIC interpreter",
-    },
-    MemoryLocation {
-        name: "Character ROM",
-        address: 0xD000,
-        length: 0x1000,
-        description: "Character patterns",
-    },
+    // ── CPU / Zero page ───────────────────────────────────────────
     MemoryLocation {
         name: "Zero Page",
         address: 0x0000,
         length: 0x100,
-        description: "Fast access memory",
+        description: "Fast-access CPU variables",
     },
     MemoryLocation {
         name: "Stack",
         address: 0x0100,
         length: 0x100,
-        description: "Processor stack",
+        description: "6510 hardware stack",
     },
     MemoryLocation {
         name: "Keyboard Buffer",
         address: 0x0277,
         length: 0x0A,
-        description: "Typed characters",
+        description: "Typed characters ($C6 = count)",
     },
+    MemoryLocation {
+        name: "I/O Vectors",
+        address: 0x0300,
+        length: 0x10,
+        description: "Soft KERNAL vectors (BASIN at $0302)",
+    },
+    MemoryLocation {
+        name: "IRQ Vector",
+        address: 0x0314,
+        length: 0x10,
+        description: "$0314/15=IRQ $0316/17=BRK $0318/19=NMI",
+    },
+    // ── BASIC / program area ──────────────────────────────────────
     MemoryLocation {
         name: "BASIC Program",
         address: 0x0801,
-        length: 0x200,
-        description: "Default BASIC start",
+        length: 0x0200,
+        description: "Default BASIC program start",
+    },
+    MemoryLocation {
+        name: "BASIC Pointers",
+        address: 0x002B,
+        length: 0x0A,
+        description: "TXTTAB/VARTAB/ARYTAB/STREND/FRETOP",
+    },
+    // ── Screen / colour / sprites ─────────────────────────────────
+    MemoryLocation {
+        name: "Screen Memory",
+        address: 0x0400,
+        length: 0x0400,
+        description: "Default screen RAM (40x25 chars)",
+    },
+    MemoryLocation {
+        name: "Color RAM",
+        address: 0xD800,
+        length: 0x0400,
+        description: "Screen colour nibbles (nybble per char)",
+    },
+    MemoryLocation {
+        name: "Sprite Pointers",
+        address: 0x07F8,
+        length: 0x08,
+        description: "8 sprite data pointers (x64 = address)",
+    },
+    MemoryLocation {
+        name: "Sprite Data",
+        address: 0x0340,
+        length: 0x0200,
+        description: "Default sprite data area (8 x 64 bytes)",
+    },
+    // ── VIC-II ────────────────────────────────────────────────────
+    MemoryLocation {
+        name: "VIC-II Registers",
+        address: 0xD000,
+        length: 0x40,
+        description: "Full VIC-II register set",
+    },
+    MemoryLocation {
+        name: "VIC Colours",
+        address: 0xD020,
+        length: 0x0F,
+        description: "Border + background colour regs",
+    },
+    MemoryLocation {
+        name: "VIC Sprites",
+        address: 0xD000,
+        length: 0x20,
+        description: "Sprite position/enable regs",
+    },
+    // ── SID (all common locations) ────────────────────────────────
+    MemoryLocation {
+        name: "SID #1 $D400",
+        address: 0xD400,
+        length: 0x20,
+        description: "Primary SID chip (always present)",
+    },
+    MemoryLocation {
+        name: "SID #2 $D500",
+        address: 0xD500,
+        length: 0x20,
+        description: "2nd SID - Prophet64 / HardSID",
+    },
+    MemoryLocation {
+        name: "SID #2 $D420",
+        address: 0xD420,
+        length: 0x20,
+        description: "2nd SID - SidCard / SIDCARD2",
+    },
+    MemoryLocation {
+        name: "SID #2 $DE00",
+        address: 0xDE00,
+        length: 0x20,
+        description: "2nd SID - I/O expansion area 1",
+    },
+    MemoryLocation {
+        name: "SID #2 $DF00",
+        address: 0xDF00,
+        length: 0x20,
+        description: "2nd SID - I/O expansion area 2",
+    },
+    MemoryLocation {
+        name: "SID #3 $D440",
+        address: 0xD440,
+        length: 0x20,
+        description: "3rd SID - triple-SID configs",
+    },
+    // ── CIA chips ─────────────────────────────────────────────────
+    MemoryLocation {
+        name: "CIA #1",
+        address: 0xDC00,
+        length: 0x10,
+        description: "Keyboard/joystick/IRQ timers",
+    },
+    MemoryLocation {
+        name: "CIA #2",
+        address: 0xDD00,
+        length: 0x10,
+        description: "Serial port/NMI/VIC bank select",
+    },
+    MemoryLocation {
+        name: "CIA1 Timer A",
+        address: 0xDC04,
+        length: 0x04,
+        description: "Timer A lo/hi + Timer B lo/hi",
+    },
+    // ── ROM areas ─────────────────────────────────────────────────
+    MemoryLocation {
+        name: "Kernal ROM",
+        address: 0xE000,
+        length: 0x2000,
+        description: "8 KB system ROM (replaceable via Ultimate)",
+    },
+    MemoryLocation {
+        name: "BASIC ROM",
+        address: 0xA000,
+        length: 0x2000,
+        description: "8 KB BASIC interpreter ROM",
+    },
+    MemoryLocation {
+        name: "Character ROM",
+        address: 0xD000,
+        length: 0x1000,
+        description: "4 KB built-in character set",
+    },
+    // ── Hardware vectors ──────────────────────────────────────────
+    MemoryLocation {
+        name: "NMI Vector",
+        address: 0xFFFA,
+        length: 0x02,
+        description: "Hardware NMI vector (ROM)",
+    },
+    MemoryLocation {
+        name: "RESET Vector",
+        address: 0xFFFC,
+        length: 0x02,
+        description: "Hardware RESET vector (ROM)",
+    },
+    MemoryLocation {
+        name: "IRQ/BRK Vector",
+        address: 0xFFFE,
+        length: 0x02,
+        description: "Hardware IRQ/BRK vector (ROM)",
     },
 ];
 
-/// Display mode for memory view
+// ─────────────────────────────────────────────────────────────────
+//  Address space selector
+// ─────────────────────────────────────────────────────────────────
+
+/// Which memory bus to target
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AddressSpace {
+    /// Normal 64 KB C64 RAM (REST read_mem / DMAWRITE write)
+    #[default]
+    C64Ram,
+    /// REU expansion RAM up to 16 MB (SOCKET_CMD_REUWRITE, raw socket)
+    Reu,
+}
+
+impl std::fmt::Display for AddressSpace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddressSpace::C64Ram => write!(f, "C64 RAM"),
+            AddressSpace::Reu => write!(f, "REU"),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Display mode
+// ─────────────────────────────────────────────────────────────────
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DisplayMode {
     #[default]
@@ -136,22 +267,90 @@ impl std::fmt::Display for DisplayMode {
     }
 }
 
-/// Message type for memory editor events
+// ─────────────────────────────────────────────────────────────────
+//  Bookmark
+// ─────────────────────────────────────────────────────────────────
+
+/// A user-defined named memory range
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Bookmark {
+    pub label: String,
+    pub address: u32, // u32 to cover REU 24-bit space too
+    pub length: u16,
+    pub space: BookmarkSpace,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum BookmarkSpace {
+    C64Ram,
+    Reu,
+}
+
+impl std::fmt::Display for Bookmark {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let prefix = match self.space {
+            BookmarkSpace::C64Ram => "",
+            BookmarkSpace::Reu => "REU:",
+        };
+        write!(f, "{} ({}${:04X})", self.label, prefix, self.address)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Undo / redo entry
+// ─────────────────────────────────────────────────────────────────
+
+/// One reversible byte-write in C64 RAM space
+#[derive(Debug, Clone)]
+struct UndoEntry {
+    address: u16,
+    old_value: u8,
+    new_value: u8,
+    /// Offset inside `memory_data` so we can patch the local copy instantly
+    offset: usize,
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Flash info returned by READFLASH
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct FlashInfo {
+    pub page_size: u32,
+    pub page_count: u32,
+    pub pages: Vec<Vec<u8>>, // pages fetched so far
+    pub current_page: u32,
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Messages
+// ─────────────────────────────────────────────────────────────────
+
 #[derive(Debug, Clone)]
 pub enum MemoryEditorMessage {
-    // Address/length input
+    // Address / length / space
     AddressInputChanged(String),
     LengthInputChanged(String),
+    AddressSpaceChanged(AddressSpace),
 
-    // Memory operations
+    // Read/write
     ReadMemory,
     ReadMemoryComplete(Result<Vec<u8>, String>),
     WriteByteValueChanged(String),
     WriteByteConfirm,
     WriteByteCancel,
-    WriteByteComplete(Result<(), String>),
+    WriteByteComplete(Result<(usize, u8), String>),
 
-    // Save/Load dumps
+    // Undo / Redo
+    Undo,
+    Redo,
+
+    // Fill memory
+    FillValueChanged(String),
+    FillMemory,
+    FillComplete(Result<(), String>),
+
+    // Save / Load dumps
     SaveDump,
     SaveDumpPathSelected(Option<std::path::PathBuf>),
     SaveDumpComplete(Result<String, String>),
@@ -172,24 +371,84 @@ pub enum MemoryEditorMessage {
     PerformSearch,
     ClearSearch,
 
-    // Editing
-    ByteClicked(usize), // offset in memory data
+    // Byte click / edit
+    ByteClicked(usize),
 
-    // Clear/refresh
+    // Clear / refresh
     ClearMemoryView,
     RefreshMemory,
 
-    // Fill memory
-    FillValueChanged(String),
-    FillMemory,
-    FillComplete(Result<(), String>),
+    // Watch mode
+    ToggleWatch,
+    WatchTick,
+
+    // Bookmarks
+    BookmarkLabelChanged(String),
+    AddBookmark,
+    BookmarkSelected(Bookmark),
+    DeleteBookmark(usize),
+
+    // ── Raw socket DMA commands ──────────────────────────────────
+    /// SOCKET_CMD_DMAWRITE — write `data` to C64 address `offset` via raw TCP port-64
+    DmaWrite {
+        host: String,
+        password: Option<String>,
+        offset: u16,
+        data: Vec<u8>,
+    },
+    DmaWriteComplete(Result<(), String>),
+
+    /// SOCKET_CMD_DMAJUMP — like DmaWrite but triggers execution at the target address
+    DmaJump {
+        host: String,
+        password: Option<String>,
+        offset: u16,
+        data: Vec<u8>,
+    },
+    DmaJumpComplete(Result<(), String>),
+
+    /// SOCKET_CMD_REUWRITE — write into REU address space
+    ReuWrite {
+        host: String,
+        password: Option<String>,
+        reu_offset: u32, // 24-bit REU address
+        data: Vec<u8>,
+    },
+    ReuWriteComplete(Result<(), String>),
+
+    /// SOCKET_CMD_KERNALWRITE — replace the active Kernal ROM image
+    KernalWriteClicked,
+    KernalWritePathSelected(Option<std::path::PathBuf>),
+    KernalWriteComplete(Result<(), String>),
+
+    /// SOCKET_CMD_READFLASH — inspect flash memory pages
+    ReadFlashInfo,
+    FlashInfoComplete(Result<(u32, u32), String>), // (page_size, page_count)
+    ReadFlashPage(u32),
+    FlashPageComplete(Result<(u32, Vec<u8>), String>),
+    FlashPageChanged(String),
 }
 
-/// Memory Editor state
+// ─────────────────────────────────────────────────────────────────
+//  State for byte editing
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct EditingByte {
+    offset: usize,
+    original_value: u8,
+    new_value_input: String,
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Main editor state
+// ─────────────────────────────────────────────────────────────────
+
 pub struct MemoryEditor {
-    // Current address and length
-    current_address: u16,
+    // Address / length / space
+    current_address: u32, // u32 covers both C64 (16-bit) and REU (24-bit)
     display_length: u16,
+    address_space: AddressSpace,
 
     // Input fields
     address_input: String,
@@ -199,35 +458,36 @@ pub struct MemoryEditor {
 
     // Memory data
     memory_data: Option<Vec<u8>>,
-
-    // Pending load data (waiting for user confirmation to write)
     pending_load_data: Option<Vec<u8>>,
 
-    // Display settings
+    // Display
     display_mode: DisplayMode,
-
-    // Search results (offsets)
     search_matches: Vec<usize>,
-
-    // Selected quick location
     selected_location: Option<MemoryLocation>,
-
-    // Byte editing state
     editing_byte: Option<EditingByte>,
 
-    // Loading state
+    // Undo / Redo stacks (only for C64 RAM byte writes)
+    undo_stack: Vec<UndoEntry>,
+    redo_stack: Vec<UndoEntry>,
+
+    // Watch / live-refresh
+    watch_active: bool,
+
+    // Bookmarks
+    bookmarks: Vec<Bookmark>,
+    bookmark_label_input: String,
+    selected_bookmark: Option<usize>,
+
+    // Flash inspector
+    flash_info: Option<FlashInfo>,
+    flash_page_input: String,
+
+    // Kernal write
+    kernal_pending_path: Option<std::path::PathBuf>,
+
+    // Loading / busy
     is_loading: bool,
-
-    // Error/status message
     status_message: Option<String>,
-}
-
-/// State for editing a single byte
-#[derive(Debug, Clone)]
-struct EditingByte {
-    offset: usize,
-    original_value: u8,
-    new_value_input: String,
 }
 
 impl MemoryEditor {
@@ -235,6 +495,7 @@ impl MemoryEditor {
         Self {
             current_address: 0x0400,
             display_length: 0x100,
+            address_space: AddressSpace::C64Ram,
             address_input: "0400".to_string(),
             length_input: "256".to_string(),
             search_input: String::new(),
@@ -245,78 +506,139 @@ impl MemoryEditor {
             search_matches: Vec::new(),
             selected_location: None,
             editing_byte: None,
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
+            watch_active: false,
+            bookmarks: Vec::new(),
+            bookmark_label_input: String::new(),
+            selected_bookmark: None,
+            flash_info: None,
+            flash_page_input: "0".to_string(),
+            kernal_pending_path: None,
             is_loading: false,
             status_message: None,
         }
     }
 
+    // ── Subscription: watch ticker ───────────────────────────────
+
+    /// Merged into the app's `Subscription::batch`. When watch is on, fires
+    /// `WatchTick` every 500 ms so the UI refreshes live.
+    pub fn subscription(&self) -> Subscription<MemoryEditorMessage> {
+        if self.watch_active && self.memory_data.is_some() {
+            iced::time::every(std::time::Duration::from_millis(500))
+                .map(|_| MemoryEditorMessage::WatchTick)
+        } else {
+            Subscription::none()
+        }
+    }
+
+    // ── Update ───────────────────────────────────────────────────
+
+    /// `host` and `password` are needed by the raw-socket helpers.
+    /// Pass `self.settings.connection.host.clone()` and
+    /// `self.settings.connection.password.clone()` from the parent update.
     pub fn update(
         &mut self,
         message: MemoryEditorMessage,
         connection: Option<Arc<TokioMutex<Rest>>>,
+        host: Option<String>,
+        password: Option<String>,
     ) -> Task<MemoryEditorMessage> {
         match message {
+            // ── Address / length / space ─────────────────────────
+            MemoryEditorMessage::AddressSpaceChanged(space) => {
+                self.address_space = space;
+                // Reset address input width to 6 hex chars for REU (24-bit)
+                let max_digits = if space == AddressSpace::Reu { 6 } else { 4 };
+                let filtered: String = self
+                    .address_input
+                    .chars()
+                    .filter(|c| c.is_ascii_hexdigit())
+                    .take(max_digits)
+                    .collect();
+                self.address_input = filtered.to_uppercase();
+                if let Ok(addr) = u32::from_str_radix(&self.address_input, 16) {
+                    self.current_address = addr;
+                }
+                Task::none()
+            }
+
             MemoryEditorMessage::AddressInputChanged(value) => {
-                // Only allow hex characters
+                let max_digits = if self.address_space == AddressSpace::Reu {
+                    6
+                } else {
+                    4
+                };
                 let filtered: String = value
                     .chars()
                     .filter(|c| c.is_ascii_hexdigit())
-                    .take(4)
+                    .take(max_digits)
                     .collect();
                 self.address_input = filtered.to_uppercase();
-
-                if let Ok(addr) = u16::from_str_radix(&self.address_input, 16) {
+                if let Ok(addr) = u32::from_str_radix(&self.address_input, 16) {
                     self.current_address = addr;
                 }
                 Task::none()
             }
 
             MemoryEditorMessage::LengthInputChanged(value) => {
-                // Only allow digits
                 let filtered: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
                 self.length_input = filtered;
-
                 if let Ok(len) = self.length_input.parse::<u16>() {
-                    // Check that address + length doesn't exceed 0xFFFF
-                    let max_len = 0xFFFFu16
-                        .saturating_sub(self.current_address)
-                        .saturating_add(1);
-                    if len > 0 && len <= max_len {
+                    if len > 0 {
                         self.display_length = len;
                     }
                 }
                 Task::none()
             }
 
+            // ── Quick location ───────────────────────────────────
             MemoryEditorMessage::LocationSelected(location) => {
                 self.selected_location = Some(location.clone());
-                self.current_address = location.address;
+                self.current_address = location.address as u32;
                 self.display_length = location.length;
                 self.address_input = format!("{:04X}", location.address);
                 self.length_input = location.length.to_string();
+                self.address_space = AddressSpace::C64Ram;
                 self.status_message = Some(format!("Selected: {}", location.description));
-
-                // Auto-read the memory
                 if connection.is_some() {
-                    return self.update(MemoryEditorMessage::ReadMemory, connection);
+                    return self.update(
+                        MemoryEditorMessage::ReadMemory,
+                        connection,
+                        host,
+                        password,
+                    );
                 }
                 Task::none()
             }
 
+            // ── Read ─────────────────────────────────────────────
             MemoryEditorMessage::ReadMemory => {
-                if let Some(conn) = connection {
-                    self.is_loading = true;
-                    self.status_message = Some("Reading memory...".to_string());
-                    let address = self.current_address;
-                    let length = self.display_length;
-
-                    Task::perform(
-                        async move { read_memory_async(conn, address, length).await },
-                        MemoryEditorMessage::ReadMemoryComplete,
-                    )
-                } else {
-                    self.status_message = Some("Not connected to Ultimate64".to_string());
-                    Task::none()
+                match self.address_space {
+                    AddressSpace::C64Ram => {
+                        if let Some(conn) = connection {
+                            self.is_loading = true;
+                            self.status_message = Some("Reading memory…".to_string());
+                            let address = self.current_address as u16;
+                            let length = self.display_length;
+                            Task::perform(
+                                async move { read_memory_async(conn, address, length).await },
+                                MemoryEditorMessage::ReadMemoryComplete,
+                            )
+                        } else {
+                            self.status_message = Some("Not connected to Ultimate64".to_string());
+                            Task::none()
+                        }
+                    }
+                    AddressSpace::Reu => {
+                        // REU has no REST read endpoint; show a placeholder
+                        self.status_message = Some(
+                            "REU read not available via REST — write-only via raw socket"
+                                .to_string(),
+                        );
+                        Task::none()
+                    }
                 }
             }
 
@@ -332,13 +654,40 @@ impl MemoryEditor {
                         self.memory_data = Some(data);
                         self.search_matches.clear();
                     }
-                    Err(e) => {
-                        self.status_message = Some(format!("Read failed: {}", e));
+                    Err(e) => self.status_message = Some(format!("Read failed: {}", e)),
+                }
+                Task::none()
+            }
+
+            // ── Watch ────────────────────────────────────────────
+            MemoryEditorMessage::ToggleWatch => {
+                self.watch_active = !self.watch_active;
+                if self.watch_active {
+                    self.status_message =
+                        Some("Watch mode ON — refreshing every 500 ms".to_string());
+                } else {
+                    self.status_message = Some("Watch mode OFF".to_string());
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::WatchTick => {
+                if self.watch_active && !self.is_loading {
+                    // Silently re-read without updating status_message so it doesn't flicker
+                    if let Some(conn) = connection {
+                        let address = self.current_address as u16;
+                        let length = self.display_length;
+                        self.is_loading = true;
+                        return Task::perform(
+                            async move { read_memory_async(conn, address, length).await },
+                            MemoryEditorMessage::ReadMemoryComplete,
+                        );
                     }
                 }
                 Task::none()
             }
 
+            // ── Byte editing ─────────────────────────────────────
             MemoryEditorMessage::ByteClicked(offset) => {
                 if let Some(data) = &self.memory_data {
                     if offset < data.len() {
@@ -363,14 +712,13 @@ impl MemoryEditor {
             MemoryEditorMessage::WriteByteConfirm => {
                 if let (Some(conn), Some(edit)) = (connection, &self.editing_byte) {
                     if let Ok(value) = edit.new_value_input.parse::<u8>() {
-                        let address = self.current_address.wrapping_add(edit.offset as u16);
+                        let address =
+                            (self.current_address as u16).wrapping_add(edit.offset as u16);
                         let offset = edit.offset;
                         let new_value = value;
-
                         self.is_loading = true;
                         self.status_message =
-                            Some(format!("Writing ${:02X} to ${:04X}...", value, address));
-
+                            Some(format!("Writing ${:02X} to ${:04X}…", value, address));
                         return Task::perform(
                             async move {
                                 write_byte_async(conn, address, new_value)
@@ -378,7 +726,9 @@ impl MemoryEditor {
                                     .map(|_| (offset, new_value))
                             },
                             |result| match result {
-                                Ok(_) => MemoryEditorMessage::WriteByteComplete(Ok(())),
+                                Ok((off, val)) => {
+                                    MemoryEditorMessage::WriteByteComplete(Ok((off, val)))
+                                }
                                 Err(e) => MemoryEditorMessage::WriteByteComplete(Err(e)),
                             },
                         );
@@ -396,30 +746,138 @@ impl MemoryEditor {
             MemoryEditorMessage::WriteByteComplete(result) => {
                 self.is_loading = false;
                 match result {
-                    Ok(()) => {
-                        // Update local data
-                        if let (Some(data), Some(edit)) =
+                    Ok((offset, new_value)) => {
+                        if let (Some(data), Some(_edit)) =
                             (&mut self.memory_data, &self.editing_byte)
                         {
-                            if let Ok(value) = edit.new_value_input.parse::<u8>() {
-                                if edit.offset < data.len() {
-                                    data[edit.offset] = value;
-                                    let address =
-                                        self.current_address.wrapping_add(edit.offset as u16);
-                                    self.status_message =
-                                        Some(format!("Written ${:02X} to ${:04X}", value, address));
-                                }
+                            if offset < data.len() {
+                                let old_value = data[offset];
+                                let address =
+                                    (self.current_address as u16).wrapping_add(offset as u16);
+                                // Push undo entry
+                                self.undo_stack.push(UndoEntry {
+                                    address,
+                                    old_value,
+                                    new_value,
+                                    offset,
+                                });
+                                self.redo_stack.clear(); // new write invalidates redo
+                                data[offset] = new_value;
+                                self.status_message =
+                                    Some(format!("Written ${:02X} to ${:04X}", new_value, address));
                             }
                         }
                     }
-                    Err(e) => {
-                        self.status_message = Some(format!("Write failed: {}", e));
-                    }
+                    Err(e) => self.status_message = Some(format!("Write failed: {}", e)),
                 }
                 self.editing_byte = None;
                 Task::none()
             }
 
+            // ── Undo ─────────────────────────────────────────────
+            MemoryEditorMessage::Undo => {
+                if let (Some(entry), Some(conn)) = (self.undo_stack.pop(), connection) {
+                    let address = entry.address;
+                    let restore_value = entry.old_value;
+                    self.redo_stack.push(entry.clone());
+                    // Patch local copy immediately for snappy UI
+                    if let Some(data) = &mut self.memory_data {
+                        if entry.offset < data.len() {
+                            data[entry.offset] = restore_value;
+                        }
+                    }
+                    self.status_message = Some(format!(
+                        "Undo: restored ${:02X} at ${:04X}",
+                        restore_value, address
+                    ));
+                    self.is_loading = true;
+                    return Task::perform(
+                        async move {
+                            write_byte_async(conn, address, restore_value)
+                                .await
+                                .map(|_| ())
+                        },
+                        |r| match r {
+                            Ok(()) => MemoryEditorMessage::DmaWriteComplete(Ok(())),
+                            Err(e) => MemoryEditorMessage::DmaWriteComplete(Err(e)),
+                        },
+                    );
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::Redo => {
+                if let (Some(entry), Some(conn)) = (self.redo_stack.pop(), connection) {
+                    let address = entry.address;
+                    let new_value = entry.new_value;
+                    self.undo_stack.push(entry.clone());
+                    if let Some(data) = &mut self.memory_data {
+                        if entry.offset < data.len() {
+                            data[entry.offset] = new_value;
+                        }
+                    }
+                    self.status_message = Some(format!(
+                        "Redo: wrote ${:02X} to ${:04X}",
+                        new_value, address
+                    ));
+                    self.is_loading = true;
+                    return Task::perform(
+                        async move { write_byte_async(conn, address, new_value).await.map(|_| ()) },
+                        |r| match r {
+                            Ok(()) => MemoryEditorMessage::DmaWriteComplete(Ok(())),
+                            Err(e) => MemoryEditorMessage::DmaWriteComplete(Err(e)),
+                        },
+                    );
+                }
+                Task::none()
+            }
+
+            // ── Fill ─────────────────────────────────────────────
+            MemoryEditorMessage::FillValueChanged(value) => {
+                let filtered: String = value
+                    .chars()
+                    .filter(|c| c.is_ascii_hexdigit())
+                    .take(2)
+                    .collect();
+                self.fill_value_input = filtered.to_uppercase();
+                Task::none()
+            }
+
+            MemoryEditorMessage::FillMemory => {
+                if let Some(conn) = connection {
+                    if let Ok(value) = u8::from_str_radix(&self.fill_value_input, 16) {
+                        self.is_loading = true;
+                        let address = self.current_address as u16;
+                        let length = self.display_length;
+                        self.status_message =
+                            Some(format!("Filling {} bytes with ${:02X}…", length, value));
+                        return Task::perform(
+                            async move { fill_memory_async(conn, address, length, value).await },
+                            MemoryEditorMessage::FillComplete,
+                        );
+                    }
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::FillComplete(result) => {
+                self.is_loading = false;
+                match result {
+                    Ok(()) => {
+                        self.status_message = Some("Fill complete".to_string());
+                        return self.update(
+                            MemoryEditorMessage::ReadMemory,
+                            connection,
+                            host,
+                            password,
+                        );
+                    }
+                    Err(e) => self.status_message = Some(format!("Fill failed: {}", e)),
+                }
+                Task::none()
+            }
+
+            // ── Display mode / search ────────────────────────────
             MemoryEditorMessage::DisplayModeChanged(mode) => {
                 self.display_mode = mode;
                 Task::none()
@@ -435,12 +893,11 @@ impl MemoryEditor {
                 if let Some(data) = &self.memory_data {
                     if !self.search_input.is_empty() {
                         let matches = self.perform_search(data);
-                        if matches.is_empty() {
-                            self.status_message = Some("Pattern not found".to_string());
+                        self.status_message = if matches.is_empty() {
+                            Some("Pattern not found".to_string())
                         } else {
-                            self.status_message =
-                                Some(format!("Found {} match(es)", matches.len()));
-                        }
+                            Some(format!("Found {} match(es)", matches.len()))
+                        };
                         self.search_matches = matches;
                     }
                 }
@@ -458,74 +915,35 @@ impl MemoryEditor {
                 self.search_matches.clear();
                 self.editing_byte = None;
                 self.status_message = None;
+                self.watch_active = false;
                 Task::none()
             }
 
             MemoryEditorMessage::RefreshMemory => {
                 if self.memory_data.is_some() {
-                    return self.update(MemoryEditorMessage::ReadMemory, connection);
+                    return self.update(
+                        MemoryEditorMessage::ReadMemory,
+                        connection,
+                        host,
+                        password,
+                    );
                 }
                 Task::none()
             }
 
-            MemoryEditorMessage::FillValueChanged(value) => {
-                let filtered: String = value
-                    .chars()
-                    .filter(|c| c.is_ascii_hexdigit())
-                    .take(2)
-                    .collect();
-                self.fill_value_input = filtered.to_uppercase();
-                Task::none()
-            }
-
-            MemoryEditorMessage::FillMemory => {
-                if let Some(conn) = connection {
-                    if let Ok(value) = u8::from_str_radix(&self.fill_value_input, 16) {
-                        self.is_loading = true;
-                        let address = self.current_address;
-                        let length = self.display_length;
-                        self.status_message =
-                            Some(format!("Filling {} bytes with ${:02X}...", length, value));
-
-                        return Task::perform(
-                            async move { fill_memory_async(conn, address, length, value).await },
-                            MemoryEditorMessage::FillComplete,
-                        );
-                    }
-                }
-                Task::none()
-            }
-
-            MemoryEditorMessage::FillComplete(result) => {
-                self.is_loading = false;
-                match result {
-                    Ok(()) => {
-                        self.status_message = Some("Fill complete".to_string());
-                        // Refresh to see changes
-                        return self.update(MemoryEditorMessage::ReadMemory, connection);
-                    }
-                    Err(e) => {
-                        self.status_message = Some(format!("Fill failed: {}", e));
-                    }
-                }
-                Task::none()
-            }
-
-            // Save dump to file
+            // ── Save / Load dump ─────────────────────────────────
             MemoryEditorMessage::SaveDump => {
                 if self.memory_data.is_none() {
                     self.status_message =
                         Some("No memory data to save. Read memory first.".to_string());
                     return Task::none();
                 }
-
                 let default_name = format!(
                     "memdump_{:04X}_{:04X}.bin",
                     self.current_address,
                     self.current_address
-                        .wrapping_add(self.display_length.saturating_sub(1))
+                        .wrapping_add(self.display_length.saturating_sub(1) as u32)
                 );
-
                 Task::perform(
                     async move {
                         rfd::AsyncFileDialog::new()
@@ -534,49 +952,36 @@ impl MemoryEditor {
                             .add_filter("All files", &["*"])
                             .save_file()
                             .await
-                            .map(|handle| handle.path().to_path_buf())
+                            .map(|h| h.path().to_path_buf())
                     },
                     MemoryEditorMessage::SaveDumpPathSelected,
                 )
             }
 
             MemoryEditorMessage::SaveDumpPathSelected(path) => {
-                if let Some(path) = path {
-                    if let Some(data) = &self.memory_data {
-                        let data = data.clone();
-
-                        return Task::perform(
-                            async move {
-                                // Write binary data
-                                std::fs::write(&path, &data)
-                                    .map_err(|e| format!("Failed to save: {}", e))?;
-
-                                Ok(format!(
-                                    "Saved {} bytes to {}",
-                                    data.len(),
-                                    path.file_name().and_then(|n| n.to_str()).unwrap_or("file")
-                                ))
-                            },
-                            MemoryEditorMessage::SaveDumpComplete,
-                        );
-                    }
+                if let (Some(path), Some(data)) = (path, &self.memory_data) {
+                    let data = data.clone();
+                    return Task::perform(
+                        async move {
+                            std::fs::write(&path, &data)
+                                .map_err(|e| format!("Failed to save: {}", e))?;
+                            Ok(format!(
+                                "Saved {} bytes to {}",
+                                data.len(),
+                                path.file_name().and_then(|n| n.to_str()).unwrap_or("file")
+                            ))
+                        },
+                        MemoryEditorMessage::SaveDumpComplete,
+                    );
                 }
                 Task::none()
             }
 
             MemoryEditorMessage::SaveDumpComplete(result) => {
-                match result {
-                    Ok(msg) => {
-                        self.status_message = Some(msg);
-                    }
-                    Err(e) => {
-                        self.status_message = Some(e);
-                    }
-                }
+                self.status_message = Some(result.unwrap_or_else(|e| e));
                 Task::none()
             }
 
-            // Load dump from file
             MemoryEditorMessage::LoadDump => Task::perform(
                 async {
                     rfd::AsyncFileDialog::new()
@@ -584,7 +989,7 @@ impl MemoryEditor {
                         .add_filter("All files", &["*"])
                         .pick_file()
                         .await
-                        .map(|handle| handle.path().to_path_buf())
+                        .map(|h| h.path().to_path_buf())
                 },
                 MemoryEditorMessage::LoadDumpPathSelected,
             ),
@@ -607,13 +1012,11 @@ impl MemoryEditor {
                         let len = data.len();
                         self.pending_load_data = Some(data);
                         self.status_message = Some(format!(
-                            "Loaded {} bytes. Click 'Write to Device' to write to ${:04X}",
+                            "Loaded {} bytes — click 'Write to Device' to write to ${:04X}",
                             len, self.current_address
                         ));
                     }
-                    Err(e) => {
-                        self.status_message = Some(e);
-                    }
+                    Err(e) => self.status_message = Some(e),
                 }
                 Task::none()
             }
@@ -621,11 +1024,10 @@ impl MemoryEditor {
             MemoryEditorMessage::WriteDumpToDevice => {
                 if let (Some(conn), Some(data)) = (connection, self.pending_load_data.take()) {
                     self.is_loading = true;
-                    let address = self.current_address;
+                    let address = self.current_address as u16;
                     let len = data.len();
                     self.status_message =
-                        Some(format!("Writing {} bytes to ${:04X}...", len, address));
-
+                        Some(format!("Writing {} bytes to ${:04X}…", len, address));
                     return Task::perform(
                         async move { write_memory_async(conn, address, data).await },
                         MemoryEditorMessage::WriteDumpComplete,
@@ -641,42 +1043,307 @@ impl MemoryEditor {
                 match result {
                     Ok(()) => {
                         self.status_message = Some("Memory written successfully!".to_string());
-                        // Refresh to see changes
-                        return self.update(MemoryEditorMessage::ReadMemory, connection);
+                        return self.update(
+                            MemoryEditorMessage::ReadMemory,
+                            connection,
+                            host,
+                            password,
+                        );
                     }
-                    Err(e) => {
-                        self.status_message = Some(format!("Write failed: {}", e));
+                    Err(e) => self.status_message = Some(format!("Write failed: {}", e)),
+                }
+                Task::none()
+            }
+
+            // ── Bookmarks ────────────────────────────────────────
+            MemoryEditorMessage::BookmarkLabelChanged(label) => {
+                self.bookmark_label_input = label;
+                Task::none()
+            }
+
+            MemoryEditorMessage::AddBookmark => {
+                let label = if self.bookmark_label_input.trim().is_empty() {
+                    format!("${:04X}", self.current_address)
+                } else {
+                    self.bookmark_label_input.trim().to_string()
+                };
+                let space = match self.address_space {
+                    AddressSpace::C64Ram => BookmarkSpace::C64Ram,
+                    AddressSpace::Reu => BookmarkSpace::Reu,
+                };
+                self.bookmarks.push(Bookmark {
+                    label,
+                    address: self.current_address,
+                    length: self.display_length,
+                    space,
+                });
+                self.bookmark_label_input.clear();
+                self.status_message =
+                    Some(format!("Bookmark added ({} total)", self.bookmarks.len()));
+                Task::none()
+            }
+
+            MemoryEditorMessage::BookmarkSelected(bm) => {
+                self.address_space = match bm.space {
+                    BookmarkSpace::C64Ram => AddressSpace::C64Ram,
+                    BookmarkSpace::Reu => AddressSpace::Reu,
+                };
+                self.current_address = bm.address;
+                self.display_length = bm.length;
+                let max_digits = if self.address_space == AddressSpace::Reu {
+                    6
+                } else {
+                    4
+                };
+                self.address_input = format!("{:0width$X}", bm.address, width = max_digits);
+                self.length_input = bm.length.to_string();
+                self.status_message = Some(format!("Jumped to bookmark: {}", bm.label));
+                if connection.is_some() && self.address_space == AddressSpace::C64Ram {
+                    return self.update(
+                        MemoryEditorMessage::ReadMemory,
+                        connection,
+                        host,
+                        password,
+                    );
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::DeleteBookmark(idx) => {
+                if idx < self.bookmarks.len() {
+                    let name = self.bookmarks.remove(idx).label;
+                    self.status_message = Some(format!("Bookmark '{}' removed", name));
+                }
+                Task::none()
+            }
+
+            // ─────────────────────────────────────────────────────
+            //  Raw socket DMA commands
+            // ─────────────────────────────────────────────────────
+            MemoryEditorMessage::DmaWrite {
+                host,
+                password,
+                offset,
+                data,
+            } => {
+                self.is_loading = true;
+                self.status_message = Some(format!(
+                    "DMA-writing {} bytes to ${:04X}…",
+                    data.len(),
+                    offset
+                ));
+                Task::perform(
+                    async move { port64::write_dma(host, password, offset, data).await },
+                    MemoryEditorMessage::DmaWriteComplete,
+                )
+            }
+
+            MemoryEditorMessage::DmaWriteComplete(result) => {
+                self.is_loading = false;
+                match &result {
+                    Ok(()) => self.status_message = Some("DMA write complete".to_string()),
+                    Err(e) => self.status_message = Some(format!("DMA write failed: {}", e)),
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::DmaJump {
+                host,
+                password,
+                offset,
+                data,
+            } => {
+                self.is_loading = true;
+                self.status_message = Some(format!(
+                    "DMA-jump: loading {} bytes, jumping to ${:04X}…",
+                    data.len(),
+                    offset
+                ));
+                Task::perform(
+                    async move { port64::write_dma_jump(host, password, offset, data).await },
+                    MemoryEditorMessage::DmaJumpComplete,
+                )
+            }
+
+            MemoryEditorMessage::DmaJumpComplete(result) => {
+                self.is_loading = false;
+                match &result {
+                    Ok(()) => self.status_message = Some("DMA jump dispatched".to_string()),
+                    Err(e) => self.status_message = Some(format!("DMA jump failed: {}", e)),
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::ReuWrite {
+                host,
+                password,
+                reu_offset,
+                data,
+            } => {
+                self.is_loading = true;
+                self.status_message = Some(format!(
+                    "Writing {} bytes to REU ${:06X}…",
+                    data.len(),
+                    reu_offset
+                ));
+                Task::perform(
+                    async move { port64::write_reu(host, password, reu_offset, data).await },
+                    MemoryEditorMessage::ReuWriteComplete,
+                )
+            }
+
+            MemoryEditorMessage::ReuWriteComplete(result) => {
+                self.is_loading = false;
+                match &result {
+                    Ok(()) => self.status_message = Some("REU write complete".to_string()),
+                    Err(e) => self.status_message = Some(format!("REU write failed: {}", e)),
+                }
+                Task::none()
+            }
+
+            // ── Kernal write ─────────────────────────────────────
+            MemoryEditorMessage::KernalWriteClicked => Task::perform(
+                async {
+                    rfd::AsyncFileDialog::new()
+                        .add_filter("Kernal ROM", &["bin", "rom"])
+                        .add_filter("All files", &["*"])
+                        .set_title("Select Kernal ROM image")
+                        .pick_file()
+                        .await
+                        .map(|h| h.path().to_path_buf())
+                },
+                MemoryEditorMessage::KernalWritePathSelected,
+            ),
+
+            MemoryEditorMessage::KernalWritePathSelected(path_opt) => {
+                if let (Some(path), Some(h), Some(pw)) =
+                    (path_opt, host.clone(), Some(password.clone()))
+                {
+                    self.kernal_pending_path = Some(path.clone());
+                    self.is_loading = true;
+                    self.status_message = Some("Sending Kernal ROM image…".to_string());
+                    return Task::perform(
+                        async move {
+                            let data = std::fs::read(&path)
+                                .map_err(|e| format!("Read ROM failed: {}", e))?;
+                            port64::write_kernal(h, pw, data).await
+                        },
+                        MemoryEditorMessage::KernalWriteComplete,
+                    );
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::KernalWriteComplete(result) => {
+                self.is_loading = false;
+                match &result {
+                    Ok(()) => {
+                        self.status_message = Some("Kernal ROM replaced successfully".to_string())
                     }
+                    Err(e) => self.status_message = Some(format!("Kernal write failed: {}", e)),
+                }
+                Task::none()
+            }
+
+            // ── Flash inspector ──────────────────────────────────
+            MemoryEditorMessage::ReadFlashInfo => {
+                if let Some(h) = host.clone() {
+                    self.is_loading = true;
+                    self.status_message = Some("Reading flash info…".to_string());
+                    return Task::perform(
+                        async move { port64::flash_info(h, password).await },
+                        MemoryEditorMessage::FlashInfoComplete,
+                    );
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::FlashInfoComplete(result) => {
+                self.is_loading = false;
+                match result {
+                    Ok((page_size, page_count)) => {
+                        self.flash_info = Some(FlashInfo {
+                            page_size,
+                            page_count,
+                            pages: Vec::new(),
+                            current_page: 0,
+                        });
+                        self.status_message = Some(format!(
+                            "Flash: {} pages × {} bytes = {} KB",
+                            page_count,
+                            page_size,
+                            (page_count as u64 * page_size as u64) / 1024
+                        ));
+                    }
+                    Err(e) => self.status_message = Some(format!("Flash info failed: {}", e)),
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::FlashPageChanged(value) => {
+                self.flash_page_input = value.chars().filter(|c| c.is_ascii_digit()).collect();
+                Task::none()
+            }
+
+            MemoryEditorMessage::ReadFlashPage(page) => {
+                if let Some(h) = host.clone() {
+                    self.is_loading = true;
+                    self.status_message = Some(format!("Reading flash page {}…", page));
+                    if let Some(fi) = &mut self.flash_info {
+                        fi.current_page = page;
+                    }
+                    return Task::perform(
+                        async move { port64::flash_page(h, password, page).await },
+                        MemoryEditorMessage::FlashPageComplete,
+                    );
+                }
+                Task::none()
+            }
+
+            MemoryEditorMessage::FlashPageComplete(result) => {
+                self.is_loading = false;
+                match result {
+                    Ok((page, data)) => {
+                        if let Some(fi) = &mut self.flash_info {
+                            // Store/replace page
+                            if page as usize >= fi.pages.len() {
+                                fi.pages.resize(page as usize + 1, Vec::new());
+                            }
+                            let len = data.len();
+                            fi.pages[page as usize] = data;
+                            self.status_message =
+                                Some(format!("Flash page {} read ({} bytes)", page, len));
+                        }
+                    }
+                    Err(e) => self.status_message = Some(format!("Flash read failed: {}", e)),
                 }
                 Task::none()
             }
         }
     }
 
+    // ── Search ───────────────────────────────────────────────────
+
     fn perform_search(&self, data: &[u8]) -> Vec<usize> {
         let search_text = self.search_input.trim().to_lowercase();
         let mut matches = Vec::new();
 
-        // Try hex search first if it looks like hex
         let is_hex = search_text
             .chars()
             .all(|c| c.is_ascii_hexdigit() || c.is_whitespace());
 
         if is_hex && search_text.len() >= 2 {
-            // Parse hex bytes
             let hex_clean: String = search_text.chars().filter(|c| !c.is_whitespace()).collect();
             if hex_clean.len() % 2 == 0 {
                 let mut search_bytes = Vec::new();
                 for chunk in hex_clean.as_bytes().chunks(2) {
-                    if let Ok(byte_str) = std::str::from_utf8(chunk) {
-                        if let Ok(byte) = u8::from_str_radix(byte_str, 16) {
-                            search_bytes.push(byte);
+                    if let Ok(s) = std::str::from_utf8(chunk) {
+                        if let Ok(b) = u8::from_str_radix(s, 16) {
+                            search_bytes.push(b);
                         }
                     }
                 }
-
                 if !search_bytes.is_empty() {
-                    // Search for byte pattern
                     for i in 0..=data.len().saturating_sub(search_bytes.len()) {
                         if data[i..].starts_with(&search_bytes) {
                             matches.push(i);
@@ -687,12 +1354,10 @@ impl MemoryEditor {
             }
         }
 
-        // Fall back to ASCII search
         let search_bytes = search_text.as_bytes();
         if !search_bytes.is_empty() {
             for i in 0..=data.len().saturating_sub(search_bytes.len()) {
                 let window = &data[i..i + search_bytes.len()];
-                // Case-insensitive ASCII search
                 if window
                     .iter()
                     .zip(search_bytes)
@@ -702,9 +1367,12 @@ impl MemoryEditor {
                 }
             }
         }
-
         matches
     }
+
+    // ─────────────────────────────────────────────────────────────
+    //  View
+    // ─────────────────────────────────────────────────────────────
 
     pub fn view(&self, is_connected: bool, font_size: u32) -> Element<'_, MemoryEditorMessage> {
         let content: Element<'_, MemoryEditorMessage> = if !is_connected {
@@ -722,6 +1390,8 @@ impl MemoryEditor {
                 rule::horizontal(1),
                 if self.memory_data.is_some() {
                     self.view_memory_display(font_size)
+                } else if self.flash_info.is_some() {
+                    self.view_flash_inspector(font_size)
                 } else {
                     self.view_quick_locations(font_size)
                 },
@@ -737,73 +1407,89 @@ impl MemoryEditor {
             .into()
     }
 
+    // ── Controls bar ─────────────────────────────────────────────
+
     fn view_controls(&self, font_size: u32) -> Element<'_, MemoryEditorMessage> {
-        let small_font = font_size.saturating_sub(2);
+        let sf = font_size.saturating_sub(2); // small font
+
+        // Address space picker
+        let space_picker = pick_list(
+            vec![AddressSpace::C64Ram, AddressSpace::Reu],
+            Some(self.address_space),
+            MemoryEditorMessage::AddressSpaceChanged,
+        )
+        .text_size(sf)
+        .width(Length::Fixed(90.0));
 
         // Address input
-        let address_input = row![
-            text("Address: $").size(small_font),
+        let addr_prefix = if self.address_space == AddressSpace::Reu {
+            "REU: $"
+        } else {
+            "Address: $"
+        };
+        let address_row = row![
+            text(addr_prefix).size(sf),
             text_input("0400", &self.address_input)
                 .on_input(MemoryEditorMessage::AddressInputChanged)
-                .width(Length::Fixed(60.0))
-                .size(small_font),
+                .width(Length::Fixed(70.0))
+                .size(sf),
         ]
         .spacing(5)
         .align_y(iced::Alignment::Center);
 
-        // Length input
-        let length_input = row![
-            text("Length:").size(small_font),
+        let length_row = row![
+            text("Length:").size(sf),
             text_input("256", &self.length_input)
                 .on_input(MemoryEditorMessage::LengthInputChanged)
                 .width(Length::Fixed(60.0))
-                .size(small_font),
-            text("bytes").size(small_font),
+                .size(sf),
+            text("bytes").size(sf),
         ]
         .spacing(5)
         .align_y(iced::Alignment::Center);
 
-        // Read button
-        let read_btn = button(text("Read").size(small_font))
-            .on_press_maybe(if self.is_loading {
-                None
-            } else {
-                Some(MemoryEditorMessage::ReadMemory)
-            })
+        let read_btn = button(text("Read").size(sf))
+            .on_press_maybe(
+                if self.is_loading || self.address_space == AddressSpace::Reu {
+                    None
+                } else {
+                    Some(MemoryEditorMessage::ReadMemory)
+                },
+            )
             .padding([5, 15]);
 
-        // Quick location picker
         let location_picker = pick_list(
             MEMORY_LOCATIONS.to_vec(),
             self.selected_location.clone(),
             MemoryEditorMessage::LocationSelected,
         )
-        .placeholder("Quick Locations...")
+        .placeholder("Quick Locations…")
         .width(Length::Fixed(200.0))
-        .text_size(small_font);
+        .text_size(sf);
 
-        // First row: address, length, read button, quick location
         let first_row = row![
-            address_input,
-            Space::new().width(Length::Fixed(20.0)),
-            length_input,
+            space_picker,
+            Space::new().width(Length::Fixed(10.0)),
+            address_row,
+            Space::new().width(Length::Fixed(10.0)),
+            length_row,
             Space::new().width(Length::Fixed(10.0)),
             read_btn,
-            Space::new().width(Length::Fixed(20.0)),
+            Space::new().width(Length::Fixed(10.0)),
             location_picker,
         ]
         .spacing(10)
         .align_y(iced::Alignment::Center);
 
-        // Search input
+        // Search + display mode row
         let search_row = row![
-            text("Search:").size(small_font),
+            text("Search:").size(sf),
             text_input("Hex or ASCII", &self.search_input)
                 .on_input(MemoryEditorMessage::SearchInputChanged)
                 .on_submit(MemoryEditorMessage::PerformSearch)
                 .width(Length::Fixed(150.0))
-                .size(small_font),
-            button(text("Find").size(small_font))
+                .size(sf),
+            button(text("Find").size(sf))
                 .on_press_maybe(
                     if self.search_input.is_empty() || self.memory_data.is_none() {
                         None
@@ -812,11 +1498,11 @@ impl MemoryEditor {
                     }
                 )
                 .padding([5, 10]),
-            button(text("Clear").size(small_font))
+            button(text("Clear").size(sf))
                 .on_press(MemoryEditorMessage::ClearSearch)
                 .padding([5, 10]),
             Space::new().width(Length::Fixed(20.0)),
-            text("Display:").size(small_font),
+            text("Display:").size(sf),
             pick_list(
                 vec![
                     DisplayMode::Hex,
@@ -827,36 +1513,35 @@ impl MemoryEditor {
                 Some(self.display_mode),
                 MemoryEditorMessage::DisplayModeChanged,
             )
-            .text_size(small_font)
+            .text_size(sf)
             .width(Length::Fixed(80.0)),
         ]
         .spacing(10)
         .align_y(iced::Alignment::Center);
 
-        // Fill memory row
+        // Fill + save/load row
         let fill_row = row![
-            text("Fill with: $").size(small_font),
+            text("Fill: $").size(sf),
             text_input("00", &self.fill_value_input)
                 .on_input(MemoryEditorMessage::FillValueChanged)
                 .width(Length::Fixed(40.0))
-                .size(small_font),
-            button(text("Fill Range").size(small_font))
+                .size(sf),
+            button(text("Fill Range").size(sf))
                 .on_press_maybe(if self.is_loading {
                     None
                 } else {
                     Some(MemoryEditorMessage::FillMemory)
                 })
                 .padding([5, 10]),
-            Space::new().width(Length::Fixed(20.0)),
-            // Save/Load dump buttons
-            button(text("Save Dump...").size(small_font))
+            Space::new().width(Length::Fixed(15.0)),
+            button(text("Save Dump…").size(sf))
                 .on_press_maybe(if self.is_loading || self.memory_data.is_none() {
                     None
                 } else {
                     Some(MemoryEditorMessage::SaveDump)
                 })
                 .padding([5, 10]),
-            button(text("Load Dump...").size(small_font))
+            button(text("Load Dump…").size(sf))
                 .on_press_maybe(if self.is_loading {
                     None
                 } else {
@@ -867,7 +1552,71 @@ impl MemoryEditor {
         .spacing(10)
         .align_y(iced::Alignment::Center);
 
-        // Status row with optional "Write to Device" button
+        // Undo / Redo / Watch row
+        let undo_row = row![
+            button(text("⟲ Undo").size(sf))
+                .on_press_maybe(if self.undo_stack.is_empty() {
+                    None
+                } else {
+                    Some(MemoryEditorMessage::Undo)
+                })
+                .padding([5, 10]),
+            button(text("⟳ Redo").size(sf))
+                .on_press_maybe(if self.redo_stack.is_empty() {
+                    None
+                } else {
+                    Some(MemoryEditorMessage::Redo)
+                })
+                .padding([5, 10]),
+            text(format!(
+                "({} / {})",
+                self.undo_stack.len(),
+                self.redo_stack.len()
+            ))
+            .size(sf),
+            Space::new().width(Length::Fixed(20.0)),
+            button(
+                text(if self.watch_active {
+                    "⏹ Stop Watch"
+                } else {
+                    "👁 Watch"
+                })
+                .size(sf)
+            )
+            .on_press_maybe(if self.memory_data.is_none() {
+                None
+            } else {
+                Some(MemoryEditorMessage::ToggleWatch)
+            })
+            .style(if self.watch_active {
+                button::primary
+            } else {
+                button::secondary
+            })
+            .padding([5, 10]),
+            Space::new().width(Length::Fixed(20.0)),
+            // Raw-socket DMA tools
+            button(text("Write ROM…").size(sf))
+                .on_press(MemoryEditorMessage::KernalWriteClicked)
+                .padding([5, 10]),
+            button(
+                text(if self.flash_info.is_some() {
+                    "Flash ✓"
+                } else {
+                    "Flash Info"
+                })
+                .size(sf)
+            )
+            .on_press(MemoryEditorMessage::ReadFlashInfo)
+            .padding([5, 10]),
+        ]
+        .spacing(10)
+        .align_y(iced::Alignment::Center);
+
+        // Bookmark row
+        let bm_row = self.view_bookmark_bar(sf);
+
+        // Status / write-to-device row
         let status_row: Element<'_, MemoryEditorMessage> = if self.pending_load_data.is_some() {
             row![
                 text(format!(
@@ -878,10 +1627,10 @@ impl MemoryEditor {
                         .unwrap_or(0),
                     self.current_address
                 ))
-                .size(small_font)
+                .size(sf)
                 .color(iced::Color::from_rgb(0.3, 0.8, 0.3)),
                 Space::new().width(Length::Fixed(10.0)),
-                button(text("Write to Device").size(small_font))
+                button(text("Write to Device").size(sf))
                     .on_press_maybe(if self.is_loading {
                         None
                     } else {
@@ -897,9 +1646,9 @@ impl MemoryEditor {
         } else {
             row![
                 if let Some(msg) = &self.status_message {
-                    text(msg).size(small_font)
+                    text(msg).size(sf)
                 } else {
-                    text("").size(small_font)
+                    text("").size(sf)
                 },
                 Space::new().width(Length::Fill),
             ]
@@ -908,71 +1657,108 @@ impl MemoryEditor {
             .into()
         };
 
-        column![first_row, search_row, fill_row, status_row]
-            .spacing(8)
-            .into()
+        column![
+            first_row, search_row, fill_row, undo_row, bm_row, status_row
+        ]
+        .spacing(8)
+        .into()
     }
 
+    // ── Bookmark bar ─────────────────────────────────────────────
+
+    fn view_bookmark_bar(&self, sf: u32) -> Element<'_, MemoryEditorMessage> {
+        let mut bm_row = Row::new()
+            .spacing(8)
+            .align_y(iced::Alignment::Center)
+            .push(text("Bookmarks:").size(sf));
+
+        for (i, bm) in self.bookmarks.iter().enumerate() {
+            bm_row = bm_row.push(
+                button(text(&*bm.label).size(sf.saturating_sub(1)))
+                    .on_press(MemoryEditorMessage::BookmarkSelected(bm.clone()))
+                    .style(button::secondary)
+                    .padding([3, 8]),
+            );
+            bm_row = bm_row.push(
+                button(text("✕").size(sf.saturating_sub(2)))
+                    .on_press(MemoryEditorMessage::DeleteBookmark(i))
+                    .style(button::danger)
+                    .padding([3, 5]),
+            );
+        }
+
+        bm_row = bm_row.push(
+            text_input("Label…", &self.bookmark_label_input)
+                .on_input(MemoryEditorMessage::BookmarkLabelChanged)
+                .on_submit(MemoryEditorMessage::AddBookmark)
+                .width(Length::Fixed(120.0))
+                .size(sf),
+        );
+        bm_row = bm_row.push(
+            button(text("+ Add").size(sf))
+                .on_press(MemoryEditorMessage::AddBookmark)
+                .padding([3, 8]),
+        );
+
+        bm_row.into()
+    }
+
+    // ── Memory hex display ───────────────────────────────────────
+
     fn view_memory_display(&self, font_size: u32) -> Element<'_, MemoryEditorMessage> {
-        let small_font = font_size.saturating_sub(2);
-        let mono_font = font_size.saturating_sub(3);
+        let sf = font_size.saturating_sub(2);
+        let mf = font_size.saturating_sub(3);
 
         let Some(data) = &self.memory_data else {
             return Space::new().width(Length::Fill).height(Length::Fill).into();
         };
 
-        // Header bar
+        let watch_label = if self.watch_active { " 👁 LIVE" } else { "" };
         let header = row![
             text(format!(
-                "Memory at ${:04X} - {} bytes",
+                "Memory at ${:04X} — {} bytes{}",
                 self.current_address,
-                data.len()
+                data.len(),
+                watch_label
             ))
-            .size(small_font),
+            .size(sf),
             Space::new().width(Length::Fill),
-            button(text("Refresh").size(small_font))
+            button(text("Refresh").size(sf))
                 .on_press(MemoryEditorMessage::RefreshMemory)
                 .padding([5, 10]),
-            button(text("Close").size(small_font))
+            button(text("Close").size(sf))
                 .on_press(MemoryEditorMessage::ClearMemoryView)
                 .padding([5, 10]),
         ]
         .spacing(10)
         .align_y(iced::Alignment::Center);
 
-        // Build hex display rows
         let mut rows: Vec<Element<'_, MemoryEditorMessage>> = Vec::new();
 
         // Column headers
-        let mut header_row =
-            Row::new().push(text("ADDR").size(mono_font).width(Length::Fixed(50.0)));
-
-        for i in 0..16 {
-            header_row = header_row.push(
-                text(format!("{:X}", i))
-                    .size(mono_font)
-                    .width(Length::Fixed(24.0)),
-            );
+        let mut hdr_row = Row::new().push(text("ADDR").size(mf).width(Length::Fixed(50.0)));
+        for i in 0..16u8 {
+            hdr_row = hdr_row.push(text(format!("{:X}", i)).size(mf).width(Length::Fixed(24.0)));
         }
-        header_row = header_row.push(Space::new().width(Length::Fixed(10.0)));
-        header_row = header_row.push(text("ASCII").size(mono_font));
-        rows.push(header_row.spacing(2).into());
+        hdr_row = hdr_row
+            .push(Space::new().width(Length::Fixed(10.0)))
+            .push(text("ASCII").size(mf));
+        rows.push(hdr_row.spacing(2).into());
 
         // Data rows
         for (row_idx, chunk) in data.chunks(16).enumerate() {
-            let row_address = self.current_address.wrapping_add((row_idx * 16) as u16);
-            let row_offset_base = row_idx * 16;
+            let row_addr = (self.current_address as u16).wrapping_add((row_idx * 16) as u16);
+            let row_base = row_idx * 16;
 
             let mut data_row = Row::new().push(
-                text(format!("{:04X}", row_address))
-                    .size(mono_font)
+                text(format!("{:04X}", row_addr))
+                    .size(mf)
                     .width(Length::Fixed(50.0))
                     .color(iced::Color::from_rgb(0.4, 0.5, 0.9)),
             );
 
-            // Hex bytes
-            for (byte_idx, &byte) in chunk.iter().enumerate() {
-                let offset = row_offset_base + byte_idx;
+            for (bi, &byte) in chunk.iter().enumerate() {
+                let offset = row_base + bi;
                 let is_match = self.search_matches.contains(&offset);
                 let is_editing = self
                     .editing_byte
@@ -1001,28 +1787,20 @@ impl MemoryEditor {
                 };
 
                 let byte_widget = if is_editing {
-                    container(
-                        text(byte_text.clone())
-                            .size(mono_font)
-                            .color(iced::Color::BLACK),
-                    )
-                    .style(editing_style)
-                    .width(Length::Fixed(width))
+                    container(text(byte_text.clone()).size(mf).color(iced::Color::BLACK))
+                        .style(editing_style)
+                        .width(Length::Fixed(width))
                 } else if is_match {
-                    container(
-                        text(byte_text.clone())
-                            .size(mono_font)
-                            .color(iced::Color::BLACK),
-                    )
-                    .style(highlight_style)
-                    .width(Length::Fixed(width))
+                    container(text(byte_text.clone()).size(mf).color(iced::Color::BLACK))
+                        .style(highlight_style)
+                        .width(Length::Fixed(width))
                 } else {
-                    container(text(byte_text.clone()).size(mono_font)).width(Length::Fixed(width))
+                    container(text(byte_text.clone()).size(mf)).width(Length::Fixed(width))
                 };
 
-                let tooltip_text = format!(
+                let tip = format!(
                     "${:04X}: {} ({})",
-                    self.current_address.wrapping_add(offset as u16),
+                    (self.current_address as u16).wrapping_add(offset as u16),
                     byte,
                     if byte >= 32 && byte <= 126 {
                         format!("'{}'", byte as char)
@@ -1036,19 +1814,17 @@ impl MemoryEditor {
                         .on_press(MemoryEditorMessage::ByteClicked(offset))
                         .padding(0)
                         .style(button::text),
-                    container(text(tooltip_text).size(small_font))
+                    container(text(tip).size(sf))
                         .padding(6)
                         .style(tooltip_style),
                     tooltip::Position::Bottom,
                 ));
             }
 
-            // Pad remaining columns if less than 16 bytes
             for _ in chunk.len()..16 {
                 data_row = data_row.push(Space::new().width(Length::Fixed(24.0)));
             }
 
-            // ASCII representation
             data_row = data_row.push(Space::new().width(Length::Fixed(10.0)));
             let ascii: String = chunk
                 .iter()
@@ -1056,27 +1832,27 @@ impl MemoryEditor {
                 .collect();
             data_row = data_row.push(
                 text(ascii)
-                    .size(mono_font)
+                    .size(mf)
                     .color(iced::Color::from_rgb(0.6, 0.6, 0.6)),
             );
 
             rows.push(data_row.spacing(2).into());
         }
 
-        // Byte editing dialog overlay
-        let memory_content: Element<'_, MemoryEditorMessage> =
+        let mem_scroll: Element<'_, MemoryEditorMessage> =
             scrollable(Column::with_children(rows).spacing(1))
                 .height(Length::Fill)
                 .into();
 
-        let content = if let Some(edit) = &self.editing_byte {
-            let address = self.current_address.wrapping_add(edit.offset as u16);
+        // Optional byte-edit dialog
+        if let Some(edit) = &self.editing_byte {
+            let address = (self.current_address as u16).wrapping_add(edit.offset as u16);
             let dialog = container(
                 column![
                     text(format!("Edit byte at ${:04X}", address)).size(font_size),
                     rule::horizontal(1),
                     row![
-                        text("Current:").size(small_font),
+                        text("Current:").size(sf),
                         text(format!(
                             "${:02X} ({}) '{}'",
                             edit.original_value,
@@ -1087,23 +1863,23 @@ impl MemoryEditor {
                                 '.'
                             }
                         ))
-                        .size(small_font),
+                        .size(sf),
                     ]
                     .spacing(10),
                     row![
-                        text("New value (0-255):").size(small_font),
+                        text("New value (0–255):").size(sf),
                         text_input("0", &edit.new_value_input)
                             .on_input(MemoryEditorMessage::WriteByteValueChanged)
                             .on_submit(MemoryEditorMessage::WriteByteConfirm)
                             .width(Length::Fixed(80.0))
-                            .size(small_font),
+                            .size(sf),
                     ]
                     .spacing(10),
                     row![
-                        button(text("Write").size(small_font))
+                        button(text("Write").size(sf))
                             .on_press(MemoryEditorMessage::WriteByteConfirm)
                             .padding([5, 15]),
-                        button(text("Cancel").size(small_font))
+                        button(text("Cancel").size(sf))
                             .on_press(MemoryEditorMessage::WriteByteCancel)
                             .padding([5, 15]),
                     ]
@@ -1119,7 +1895,7 @@ impl MemoryEditor {
                 header,
                 rule::horizontal(1),
                 container(column![
-                    memory_content,
+                    mem_scroll,
                     container(dialog)
                         .width(Length::Fill)
                         .center_x(Length::Fill)
@@ -1130,45 +1906,129 @@ impl MemoryEditor {
             .spacing(5)
             .into()
         } else {
-            column![header, rule::horizontal(1), memory_content]
+            column![header, rule::horizontal(1), mem_scroll]
                 .spacing(5)
                 .into()
-        };
-
-        content
+        }
     }
 
+    // ── Flash inspector view ──────────────────────────────────────
+
+    fn view_flash_inspector(&self, font_size: u32) -> Element<'_, MemoryEditorMessage> {
+        let sf = font_size.saturating_sub(2);
+        let mf = font_size.saturating_sub(3);
+
+        let Some(fi) = &self.flash_info else {
+            return Space::new().into();
+        };
+
+        let info_bar = row![
+            text(format!(
+                "Flash: {} pages × {} bytes ({} KB total)",
+                fi.page_count,
+                fi.page_size,
+                (fi.page_count as u64 * fi.page_size as u64) / 1024
+            ))
+            .size(sf),
+            Space::new().width(Length::Fill),
+            button(text("Close Flash").size(sf))
+                .on_press(MemoryEditorMessage::ClearMemoryView)
+                .padding([5, 10]),
+        ]
+        .spacing(10)
+        .align_y(iced::Alignment::Center);
+
+        let page_controls = row![
+            text("Page:").size(sf),
+            text_input("0", &self.flash_page_input)
+                .on_input(MemoryEditorMessage::FlashPageChanged)
+                .width(Length::Fixed(60.0))
+                .size(sf),
+            button(text("Read Page").size(sf))
+                .on_press_maybe(
+                    self.flash_page_input
+                        .parse::<u32>()
+                        .ok()
+                        .filter(|&p| p < fi.page_count && !self.is_loading)
+                        .map(MemoryEditorMessage::ReadFlashPage)
+                )
+                .padding([5, 10]),
+        ]
+        .spacing(10)
+        .align_y(iced::Alignment::Center);
+
+        // Show current page data if available
+        let page_display: Element<'_, MemoryEditorMessage> =
+            if let Ok(pg) = self.flash_page_input.parse::<usize>() {
+                if let Some(page_data) = fi.pages.get(pg).filter(|d| !d.is_empty()) {
+                    let mut rows: Vec<Element<'_, MemoryEditorMessage>> = Vec::new();
+                    for (ri, chunk) in page_data.chunks(16).enumerate() {
+                        let row_addr = (ri * 16) as u32;
+                        let mut dr = Row::new().push(
+                            text(format!("{:06X}", row_addr))
+                                .size(mf)
+                                .width(Length::Fixed(60.0))
+                                .color(iced::Color::from_rgb(0.5, 0.6, 0.9)),
+                        );
+                        for &b in chunk {
+                            dr = dr.push(
+                                text(format!("{:02X}", b))
+                                    .size(mf)
+                                    .width(Length::Fixed(24.0)),
+                            );
+                        }
+                        rows.push(dr.spacing(2).into());
+                    }
+                    scrollable(Column::with_children(rows).spacing(1))
+                        .height(Length::Fill)
+                        .into()
+                } else {
+                    text(format!("Page {} not yet fetched — click 'Read Page'", pg))
+                        .size(sf)
+                        .into()
+                }
+            } else {
+                text("Enter a page number above").size(sf).into()
+            };
+
+        column![
+            info_bar,
+            rule::horizontal(1),
+            page_controls,
+            rule::horizontal(1),
+            page_display
+        ]
+        .spacing(8)
+        .into()
+    }
+
+    // ── Quick locations grid ──────────────────────────────────────
+
     fn view_quick_locations(&self, font_size: u32) -> Element<'_, MemoryEditorMessage> {
-        let small_font = font_size.saturating_sub(2);
+        let sf = font_size.saturating_sub(2);
 
         let title = text("Common C64 Memory Locations").size(font_size + 2);
-
         let subtitle = text("Click a location to view its contents")
-            .size(small_font)
+            .size(sf)
             .color(iced::Color::from_rgb(0.6, 0.6, 0.6));
 
-        // Create location cards in a grid-like layout
         let mut rows: Vec<Element<'_, MemoryEditorMessage>> = Vec::new();
-
         for chunk in MEMORY_LOCATIONS.chunks(3) {
             let mut row_items = Row::new().spacing(10);
-
             for location in chunk {
                 let card = button(
                     container(
                         column![
-                            text(location.name)
-                                .size(small_font)
-                                .color(iced::Color::BLACK),
+                            text(location.name).size(sf).color(iced::Color::BLACK),
                             text(location.description)
-                                .size(small_font.saturating_sub(2))
+                                .size(sf.saturating_sub(2))
                                 .color(iced::Color::from_rgb(0.3, 0.3, 0.3)),
                             row![
                                 text(format!("${:04X}", location.address))
-                                    .size(small_font)
+                                    .size(sf)
                                     .color(iced::Color::from_rgb(0.2, 0.3, 0.7)),
                                 text(format!("{} bytes", location.length))
-                                    .size(small_font.saturating_sub(2))
+                                    .size(sf.saturating_sub(2))
                                     .color(iced::Color::from_rgb(0.3, 0.3, 0.3)),
                             ]
                             .spacing(10),
@@ -1181,15 +2041,11 @@ impl MemoryEditor {
                 .on_press(MemoryEditorMessage::LocationSelected(location.clone()))
                 .style(button::secondary)
                 .width(Length::Fill);
-
                 row_items = row_items.push(card);
             }
-
-            // Pad with empty space if less than 3 items in row
             for _ in chunk.len()..3 {
                 row_items = row_items.push(Space::new().width(Length::Fill));
             }
-
             rows.push(row_items.width(Length::Fill).into());
         }
 
@@ -1197,7 +2053,7 @@ impl MemoryEditor {
             column![
                 title,
                 subtitle,
-                Column::with_children(rows).spacing(10).width(Length::Fill)
+                Column::with_children(rows).spacing(10).width(Length::Fill),
             ]
             .spacing(15)
             .padding(10)
@@ -1209,7 +2065,10 @@ impl MemoryEditor {
     }
 }
 
-// Custom container style functions for iced 0.14
+// ─────────────────────────────────────────────────────────────────
+//  Style helpers
+// ─────────────────────────────────────────────────────────────────
+
 fn highlight_style(_theme: &iced::Theme) -> container::Style {
     container::Style {
         background: Some(iced::Background::Color(iced::Color::from_rgb(
@@ -1250,7 +2109,10 @@ fn tooltip_style(_theme: &iced::Theme) -> container::Style {
     }
 }
 
-// Async helper functions for memory operations
+// ─────────────────────────────────────────────────────────────────
+//  REST async helpers (unchanged from original)
+// ─────────────────────────────────────────────────────────────────
+
 async fn read_memory_async(
     connection: Arc<TokioMutex<Rest>>,
     address: u16,
@@ -1265,11 +2127,10 @@ async fn read_memory_async(
         }),
     )
     .await;
-
     match result {
         Ok(Ok(data)) => data,
         Ok(Err(e)) => Err(format!("Task error: {}", e)),
-        Err(_) => Err("Read timed out - device may be offline".to_string()),
+        Err(_) => Err("Read timed out — device may be offline".to_string()),
     }
 }
 
@@ -1287,11 +2148,10 @@ async fn write_byte_async(
         }),
     )
     .await;
-
     match result {
         Ok(Ok(r)) => r,
         Ok(Err(e)) => Err(format!("Task error: {}", e)),
-        Err(_) => Err("Write timed out - device may be offline".to_string()),
+        Err(_) => Err("Write timed out — device may be offline".to_string()),
     }
 }
 
@@ -1302,33 +2162,27 @@ async fn fill_memory_async(
     value: u8,
 ) -> Result<(), String> {
     let result = tokio::time::timeout(
-        tokio::time::Duration::from_secs(REST_TIMEOUT_SECS * 2), // Longer timeout for fill
+        tokio::time::Duration::from_secs(REST_TIMEOUT_SECS * 2),
         tokio::task::spawn_blocking(move || {
             let conn = connection.blocking_lock();
-            // Fill by writing chunks
-            let chunk_size = 256usize;
-            let fill_data: Vec<u8> = vec![value; chunk_size];
-
+            let fill_data: Vec<u8> = vec![value; RAW_CHUNK];
             let mut offset = 0u16;
             while offset < length {
                 let remaining = (length - offset) as usize;
-                let write_size = remaining.min(chunk_size);
+                let write_size = remaining.min(RAW_CHUNK);
                 let current_addr = address.wrapping_add(offset);
-
                 conn.write_mem(current_addr, &fill_data[..write_size])
                     .map_err(|e| format!("Fill failed at ${:04X}: {}", current_addr, e))?;
-
                 offset += write_size as u16;
             }
             Ok(())
         }),
     )
     .await;
-
     match result {
         Ok(Ok(r)) => r,
         Ok(Err(e)) => Err(format!("Task error: {}", e)),
-        Err(_) => Err("Fill timed out - device may be offline".to_string()),
+        Err(_) => Err("Fill timed out — device may be offline".to_string()),
     }
 }
 
@@ -1338,31 +2192,24 @@ async fn write_memory_async(
     data: Vec<u8>,
 ) -> Result<(), String> {
     let result = tokio::time::timeout(
-        tokio::time::Duration::from_secs(REST_TIMEOUT_SECS * 4), // Longer timeout for large writes
+        tokio::time::Duration::from_secs(REST_TIMEOUT_SECS * 4),
         tokio::task::spawn_blocking(move || {
             let conn = connection.blocking_lock();
-            // Write in chunks (API max is typically 256 bytes per call)
-            let chunk_size = 256usize;
-
             let mut offset = 0usize;
             while offset < data.len() {
-                let remaining = data.len() - offset;
-                let write_size = remaining.min(chunk_size);
+                let write_size = (data.len() - offset).min(RAW_CHUNK);
                 let current_addr = address.wrapping_add(offset as u16);
-
                 conn.write_mem(current_addr, &data[offset..offset + write_size])
                     .map_err(|e| format!("Write failed at ${:04X}: {}", current_addr, e))?;
-
                 offset += write_size;
             }
             Ok(())
         }),
     )
     .await;
-
     match result {
         Ok(Ok(r)) => r,
         Ok(Err(e)) => Err(format!("Task error: {}", e)),
-        Err(_) => Err("Write timed out - device may be offline".to_string()),
+        Err(_) => Err("Write timed out — device may be offline".to_string()),
     }
 }

--- a/src/port64.rs
+++ b/src/port64.rs
@@ -1,0 +1,670 @@
+//! Raw TCP port-64 client for the Ultimate 64 / Ultimate II+.
+//!
+//! Mirrors every command defined in `socket_dma.cc`.  The server listens on
+//! TCP port 64; each call opens a fresh connection, optionally authenticates,
+//! sends the command, reads any reply, then closes.
+//!
+//! # Wire protocol
+//! ```text
+//! ┌──────────┬──────────┬────────────────────┐
+//! │ cmd (2 B)│ len (2 B)│ payload (len bytes) │
+//! └──────────┴──────────┴────────────────────┘
+//! ```
+//! Both `cmd` and `len` are little-endian `u16`.
+//! All command words are in the `0xFF00–0xFFFF` range.
+//!
+//! # Authentication
+//! If a password is configured on the device every session must start with
+//! `AUTHENTICATE` before any other command, otherwise the server silently
+//! drops the connection.  [`Port64Client`] handles this automatically.
+//!
+//! # Usage
+//! ```rust,no_run
+//! use port64::Port64Client;
+//!
+//! let client = Port64Client::new("192.168.1.64", Some("secret".into()));
+//! client.dma_write(0x0400, b"HELLO WORLD").await?;
+//! client.reset().await?;
+//! ```
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+// ─────────────────────────────────────────────────────────────────
+//  Protocol constants  (mirrors socket_dma.cc #defines)
+// ─────────────────────────────────────────────────────────────────
+
+/// TCP port the Ultimate DMA service listens on.
+pub const PORT: u16 = 64;
+
+/// Default per-operation timeout in seconds.
+pub const TIMEOUT_SECS: u64 = 5;
+
+// All 25 command codes from socket_dma.cc
+pub const CMD_DMA: u16 = 0xFF01; // Load PRG via DMA
+pub const CMD_DMARUN: u16 = 0xFF02; // Load + run via DMA
+pub const CMD_KEYB: u16 = 0xFF03; // Inject keyboard buffer
+pub const CMD_RESET: u16 = 0xFF04; // Soft-reset C64
+pub const CMD_WAIT: u16 = 0xFF05; // Delay (len = ms)
+pub const CMD_DMAWRITE: u16 = 0xFF06; // Raw write to C64 address
+pub const CMD_REUWRITE: u16 = 0xFF07; // Write to REU address space
+pub const CMD_KERNALWRITE: u16 = 0xFF08; // Replace active Kernal ROM
+pub const CMD_DMAJUMP: u16 = 0xFF09; // Load + jump to address
+pub const CMD_MOUNT_IMG: u16 = 0xFF0A; // Mount disk image
+pub const CMD_RUN_IMG: u16 = 0xFF0B; // Mount + run disk image
+pub const CMD_POWEROFF: u16 = 0xFF0C; // Power off C64
+pub const CMD_RUN_CRT: u16 = 0xFF0D; // Mount + run cartridge image
+pub const CMD_IDENTIFY: u16 = 0xFF0E; // Query device identity string
+pub const CMD_AUTHENTICATE: u16 = 0xFF1F; // Password authentication
+
+// U64-only streaming commands
+pub const CMD_VICSTREAM_ON: u16 = 0xFF20;
+pub const CMD_AUDIOSTREAM_ON: u16 = 0xFF21;
+pub const CMD_DEBUGSTREAM_ON: u16 = 0xFF22;
+pub const CMD_VICSTREAM_OFF: u16 = 0xFF30;
+pub const CMD_AUDIOSTREAM_OFF: u16 = 0xFF31;
+pub const CMD_DEBUGSTREAM_OFF: u16 = 0xFF32;
+
+// Undocumented / developer-only
+pub const CMD_LOADSIDCRT: u16 = 0xFF71;
+pub const CMD_LOADBOOTCRT: u16 = 0xFF72;
+pub const CMD_READFLASH: u16 = 0xFF75;
+pub const CMD_DEBUG_REG: u16 = 0xFF76;
+
+// ─────────────────────────────────────────────────────────────────
+//  Error type
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub enum Port64Error {
+    Connect(String),
+    AuthFailed,
+    Send(String),
+    Recv(String),
+    Timeout,
+    InvalidResponse(String),
+}
+
+impl std::fmt::Display for Port64Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Port64Error::Connect(e) => write!(f, "Connect failed: {}", e),
+            Port64Error::AuthFailed => write!(f, "Authentication rejected — check password"),
+            Port64Error::Send(e) => write!(f, "Send failed: {}", e),
+            Port64Error::Recv(e) => write!(f, "Receive failed: {}", e),
+            Port64Error::Timeout => write!(f, "Timed out — device may be offline"),
+            Port64Error::InvalidResponse(e) => write!(f, "Invalid response: {}", e),
+        }
+    }
+}
+
+impl From<Port64Error> for String {
+    fn from(e: Port64Error) -> String {
+        e.to_string()
+    }
+}
+
+pub type Port64Result<T> = Result<T, Port64Error>;
+
+// ─────────────────────────────────────────────────────────────────
+//  Flash page info returned by identify_flash()
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct FlashGeometry {
+    pub page_size: u32,
+    pub page_count: u32,
+}
+
+impl FlashGeometry {
+    pub fn total_bytes(&self) -> u64 {
+        self.page_size as u64 * self.page_count as u64
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Stream kind (for start/stop streaming helpers)
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamKind {
+    Vic,
+    Audio,
+    Debug,
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Client
+// ─────────────────────────────────────────────────────────────────
+
+/// Async client for the Ultimate 64 raw TCP port-64 protocol.
+///
+/// Cheap to clone — `host` and `password` are `Arc`-backed strings internally.
+#[derive(Debug, Clone)]
+pub struct Port64Client {
+    host: String,
+    password: Option<String>,
+    timeout: std::time::Duration,
+}
+
+impl Port64Client {
+    /// Create a new client.  `host` is an IP address or hostname (no port).
+    pub fn new(host: impl Into<String>, password: Option<String>) -> Self {
+        Self {
+            host: host.into(),
+            password,
+            timeout: std::time::Duration::from_secs(TIMEOUT_SECS),
+        }
+    }
+
+    /// Override the default per-operation timeout.
+    pub fn with_timeout(mut self, secs: u64) -> Self {
+        self.timeout = std::time::Duration::from_secs(secs);
+        self
+    }
+
+    // ── Low-level session plumbing ────────────────────────────────
+
+    /// Open a TCP connection and authenticate if a password is set.
+    /// Returns the authenticated stream ready to receive commands.
+    async fn open(&self) -> Port64Result<TcpStream> {
+        let addr = format!("{}:{}", self.host, PORT);
+
+        let stream = tokio::time::timeout(self.timeout, TcpStream::connect(&addr))
+            .await
+            .map_err(|_| Port64Error::Timeout)?
+            .map_err(|e| Port64Error::Connect(e.to_string()))?;
+
+        // Disable Nagle — we send small command packets and want them out fast
+        let _ = stream.set_nodelay(true);
+
+        let mut stream = stream;
+        self.authenticate_if_needed(&mut stream).await?;
+        Ok(stream)
+    }
+
+    /// Send AUTHENTICATE if a non-empty password is configured.
+    async fn authenticate_if_needed(&self, stream: &mut TcpStream) -> Port64Result<()> {
+        let pw = match &self.password {
+            Some(p) if !p.is_empty() => p.as_bytes(),
+            _ => return Ok(()),
+        };
+
+        let pw_len = pw.len() as u16;
+        let mut pkt = Vec::with_capacity(4 + pw.len());
+        pkt.extend_from_slice(&CMD_AUTHENTICATE.to_le_bytes());
+        pkt.extend_from_slice(&pw_len.to_le_bytes());
+        pkt.extend_from_slice(pw);
+
+        stream
+            .write_all(&pkt)
+            .await
+            .map_err(|e| Port64Error::Send(e.to_string()))?;
+        stream
+            .flush()
+            .await
+            .map_err(|e| Port64Error::Send(e.to_string()))?;
+
+        let mut resp = [0u8; 1];
+        stream
+            .read_exact(&mut resp)
+            .await
+            .map_err(|e| Port64Error::Recv(e.to_string()))?;
+
+        if resp[0] != 1 {
+            return Err(Port64Error::AuthFailed);
+        }
+        Ok(())
+    }
+
+    /// Send a command packet with a raw payload (no extra framing).
+    /// `payload` is the complete byte sequence after the 4-byte header.
+    async fn send_cmd(&self, stream: &mut TcpStream, cmd: u16, payload: &[u8]) -> Port64Result<()> {
+        let len = payload.len() as u16;
+        let mut pkt = Vec::with_capacity(4 + payload.len());
+        pkt.extend_from_slice(&cmd.to_le_bytes());
+        pkt.extend_from_slice(&len.to_le_bytes());
+        pkt.extend_from_slice(payload);
+        stream
+            .write_all(&pkt)
+            .await
+            .map_err(|e| Port64Error::Send(e.to_string()))?;
+        stream
+            .flush()
+            .await
+            .map_err(|e| Port64Error::Send(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Send a command where the `len` field carries a value that is NOT the
+    /// byte-length of the following payload.  Used by `CMD_WAIT` where `len`
+    /// encodes the delay in milliseconds and no payload bytes follow.
+    async fn send_cmd_raw_len(
+        &self,
+        stream: &mut TcpStream,
+        cmd: u16,
+        len_field: u16,
+        payload: &[u8],
+    ) -> Port64Result<()> {
+        let mut pkt = Vec::with_capacity(4 + payload.len());
+        pkt.extend_from_slice(&cmd.to_le_bytes());
+        pkt.extend_from_slice(&len_field.to_le_bytes());
+        pkt.extend_from_slice(payload);
+        stream
+            .write_all(&pkt)
+            .await
+            .map_err(|e| Port64Error::Send(e.to_string()))?;
+        stream
+            .flush()
+            .await
+            .map_err(|e| Port64Error::Send(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Read exactly `n` bytes from the stream, with the client timeout.
+    async fn recv_exact(&self, stream: &mut TcpStream, n: usize) -> Port64Result<Vec<u8>> {
+        let mut buf = vec![0u8; n];
+        tokio::time::timeout(self.timeout, stream.read_exact(&mut buf))
+            .await
+            .map_err(|_| Port64Error::Timeout)?
+            .map_err(|e| Port64Error::Recv(e.to_string()))?;
+        Ok(buf)
+    }
+
+    /// Read until EOF or timeout (for variable-length replies like flash pages).
+    async fn recv_until_eof(&self, stream: &mut TcpStream) -> Port64Result<Vec<u8>> {
+        let mut data = Vec::new();
+        let mut chunk = [0u8; 512];
+        loop {
+            match tokio::time::timeout(self.timeout, stream.read(&mut chunk)).await {
+                Ok(Ok(0)) | Err(_) => break,
+                Ok(Ok(n)) => data.extend_from_slice(&chunk[..n]),
+                Ok(Err(e)) => return Err(Port64Error::Recv(e.to_string())),
+            }
+        }
+        Ok(data)
+    }
+
+    // ── Public command API ────────────────────────────────────────
+    //
+    // Every method opens a fresh session, sends the command, reads any
+    // reply, and closes.  This matches the C++ server behaviour exactly.
+
+    // ── DMA / execution commands ──────────────────────────────────
+
+    /// `CMD_DMA` — load `data` into C64 RAM via DMA (no auto-run).
+    pub async fn dma_load(&self, data: &[u8]) -> Port64Result<()> {
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_DMA, data).await
+    }
+
+    /// `CMD_DMARUN` — load `data` into C64 RAM and run it.
+    pub async fn dma_run(&self, data: &[u8]) -> Port64Result<()> {
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_DMARUN, data).await
+    }
+
+    /// `CMD_DMAWRITE` — write `data` to C64 RAM at `address`.
+    ///
+    /// Payload: `[addr_lo, addr_hi, data…]`
+    pub async fn dma_write(&self, address: u16, data: &[u8]) -> Port64Result<()> {
+        let mut payload = Vec::with_capacity(2 + data.len());
+        payload.extend_from_slice(&address.to_le_bytes());
+        payload.extend_from_slice(data);
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_DMAWRITE, &payload).await
+    }
+
+    /// `CMD_DMAJUMP` — load `data` into C64 RAM and jump to `address`.
+    pub async fn dma_jump(&self, address: u16, data: &[u8]) -> Port64Result<()> {
+        let mut payload = Vec::with_capacity(2 + data.len());
+        payload.extend_from_slice(&address.to_le_bytes());
+        payload.extend_from_slice(data);
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_DMAJUMP, &payload).await
+    }
+
+    // ── Machine control ───────────────────────────────────────────
+
+    /// `CMD_RESET` — soft-reset the C64.
+    pub async fn reset(&self) -> Port64Result<()> {
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_RESET, &[]).await
+    }
+
+    /// `CMD_POWEROFF` — power off the C64.
+    pub async fn poweroff(&self) -> Port64Result<()> {
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_POWEROFF, &[]).await
+    }
+
+    /// `CMD_WAIT` — ask the device to pause for `millis` milliseconds.
+    ///
+    /// The C++ server calls `vTaskDelay(len)` where `len` is the 16-bit
+    /// payload length field — so we encode the delay as the length with an
+    /// empty payload.
+    pub async fn wait(&self, millis: u16) -> Port64Result<()> {
+        // CMD_WAIT is special: the C++ server calls vTaskDelay(len) where
+        // `len` is the 2-byte header length field — no payload bytes follow.
+        // We use send_cmd_raw_len to put the delay value into the len field.
+        let mut s = self.open().await?;
+        self.send_cmd_raw_len(&mut s, CMD_WAIT, millis, &[]).await
+    }
+
+    // ── Keyboard injection ────────────────────────────────────────
+
+    /// `CMD_KEYB` — inject `text` into the C64 keyboard buffer (`$0277`).
+    ///
+    /// Maximum 10 characters (C64 keyboard buffer size).  The device also
+    /// updates `$00C6` (pending key count) automatically.
+    pub async fn type_keys(&self, text: &str) -> Port64Result<()> {
+        let bytes: Vec<u8> = text.bytes().take(10).collect();
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_KEYB, &bytes).await
+    }
+
+    // ── Memory / ROM operations ───────────────────────────────────
+
+    /// `CMD_REUWRITE` — write `data` into REU expansion RAM at a 24-bit `offset`.
+    ///
+    /// Payload: `[offset_lo, offset_mid, offset_hi, data…]`
+    pub async fn reu_write(&self, offset: u32, data: &[u8]) -> Port64Result<()> {
+        let mut payload = Vec::with_capacity(3 + data.len());
+        payload.push((offset & 0xFF) as u8);
+        payload.push(((offset >> 8) & 0xFF) as u8);
+        payload.push(((offset >> 16) & 0xFF) as u8);
+        payload.extend_from_slice(data);
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_REUWRITE, &payload).await
+    }
+
+    /// `CMD_KERNALWRITE` — replace the active Kernal ROM with `rom_data`.
+    ///
+    /// The C++ server does `enable_kernal(buf + 2)`, skipping the first two
+    /// bytes of the payload, so we prepend two zero bytes automatically.
+    /// `rom_data` should be exactly 8 KB (0x2000 bytes).
+    pub async fn kernal_write(&self, rom_data: &[u8]) -> Port64Result<()> {
+        let mut payload = vec![0u8, 0u8];
+        payload.extend_from_slice(rom_data);
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_KERNALWRITE, &payload).await
+    }
+
+    // ── Disk / cartridge image commands ───────────────────────────
+
+    /// `CMD_MOUNT_IMG` — upload a disk image and mount it on drive A.
+    ///
+    /// The device saves the image as `/temp/tcpimage.d64` then mounts it.
+    pub async fn mount_image(&self, image_data: &[u8]) -> Port64Result<()> {
+        // MOUNT_IMG uses a 3-byte length field: the C++ reads an extra byte
+        // after the standard 2-byte len to form a 24-bit value.
+        self.send_image_cmd(CMD_MOUNT_IMG, image_data).await
+    }
+
+    /// `CMD_RUN_IMG` — upload a disk image, mount it, and run `*` from drive A.
+    pub async fn run_image(&self, image_data: &[u8]) -> Port64Result<()> {
+        self.send_image_cmd(CMD_RUN_IMG, image_data).await
+    }
+
+    /// `CMD_RUN_CRT` — upload a cartridge image and start it.
+    ///
+    /// The device saves it as `/temp/tcpimage.crt` then calls `FileTypeCRT::execute_st`.
+    pub async fn run_crt(&self, crt_data: &[u8]) -> Port64Result<()> {
+        self.send_image_cmd(CMD_RUN_CRT, crt_data).await
+    }
+
+    /// Internal helper for the three commands that use a 24-bit length field.
+    ///
+    /// The C++ server reads 2 bytes for the length then reads one extra byte
+    /// to form a 24-bit total length for these larger payloads.
+    async fn send_image_cmd(&self, cmd: u16, data: &[u8]) -> Port64Result<()> {
+        let len = data.len();
+        let len_lo = (len & 0xFFFF) as u16;
+        let len_hi = ((len >> 16) & 0xFF) as u8;
+
+        let mut pkt = Vec::with_capacity(5 + data.len());
+        pkt.extend_from_slice(&cmd.to_le_bytes());
+        pkt.extend_from_slice(&len_lo.to_le_bytes());
+        pkt.push(len_hi);
+        pkt.extend_from_slice(data);
+
+        let mut s = self.open().await?;
+        s.write_all(&pkt)
+            .await
+            .map_err(|e| Port64Error::Send(e.to_string()))?;
+        s.flush()
+            .await
+            .map_err(|e| Port64Error::Send(e.to_string()))?;
+        Ok(())
+    }
+
+    // ── Developer / undocumented ──────────────────────────────────
+
+    /// `CMD_LOADSIDCRT` — load up to 8 KB into the SID cartridge ROM buffer.
+    pub async fn load_sid_crt(&self, data: &[u8]) -> Port64Result<()> {
+        let trimmed = if data.len() > 0x2000 {
+            &data[..0x2000]
+        } else {
+            data
+        };
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_LOADSIDCRT, trimmed).await
+    }
+
+    /// `CMD_LOADBOOTCRT` — load up to 8 KB into the boot cartridge ROM buffer.
+    pub async fn load_boot_crt(&self, data: &[u8]) -> Port64Result<()> {
+        let trimmed = if data.len() > 0x2000 {
+            &data[..0x2000]
+        } else {
+            data
+        };
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_LOADBOOTCRT, trimmed).await
+    }
+
+    // ── Device identity ───────────────────────────────────────────
+
+    /// `CMD_IDENTIFY` — query the device product title string.
+    ///
+    /// Returns the identity string, e.g. `"Ultimate 64 Elite"`.
+    /// The reply is a Pascal-style string: `[len_byte, chars…]`.
+    pub async fn identify(&self) -> Port64Result<String> {
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_IDENTIFY, &[]).await?;
+
+        // Read 1-byte length prefix
+        let len_buf = self.recv_exact(&mut s, 1).await?;
+        let len = len_buf[0] as usize;
+        if len == 0 {
+            return Ok(String::new());
+        }
+        let chars = self.recv_exact(&mut s, len).await?;
+        String::from_utf8(chars)
+            .map_err(|e| Port64Error::InvalidResponse(format!("Non-UTF8 identity: {}", e)))
+    }
+
+    // ── Flash memory ──────────────────────────────────────────────
+
+    /// `CMD_READFLASH` sub-cmd 0+1 — query flash geometry (page size + count).
+    pub async fn flash_geometry(&self) -> Port64Result<FlashGeometry> {
+        let page_size = self.flash_query(0).await?;
+        let page_count = self.flash_query(1).await?;
+        Ok(FlashGeometry {
+            page_size,
+            page_count,
+        })
+    }
+
+    /// `CMD_READFLASH` sub-cmd 2 — read one flash page by index.
+    pub async fn flash_read_page(&self, page: u32) -> Port64Result<Vec<u8>> {
+        let mut payload = [0u8; 4];
+        payload[0] = 2; // sub-command: get page
+        payload[1] = (page & 0xFF) as u8;
+        payload[2] = ((page >> 8) & 0xFF) as u8;
+        payload[3] = ((page >> 16) & 0xFF) as u8;
+
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_READFLASH, &payload).await?;
+        let data = self.recv_until_eof(&mut s).await?;
+
+        if data.is_empty() {
+            return Err(Port64Error::InvalidResponse(format!(
+                "Flash page {} returned no data",
+                page
+            )));
+        }
+        Ok(data)
+    }
+
+    /// Internal: `CMD_READFLASH` sub-cmd 0 or 1 → returns a `u32`.
+    async fn flash_query(&self, sub_cmd: u8) -> Port64Result<u32> {
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_READFLASH, &[sub_cmd]).await?;
+        let buf = self.recv_exact(&mut s, 4).await?;
+        Ok(u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]))
+    }
+
+    // ── Debug register (U64 only) ─────────────────────────────────
+
+    /// `CMD_DEBUG_REG` — read (and optionally write) the U64 debug register.
+    ///
+    /// Always returns the current register value.  If `write` is `Some(v)`
+    /// the register is updated to `v` after the read.
+    pub async fn debug_register(&self, write: Option<u8>) -> Port64Result<u8> {
+        let owned;
+        let payload: &[u8] = match write {
+            Some(v) => {
+                owned = [v];
+                &owned
+            }
+            None => &[],
+        };
+
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, CMD_DEBUG_REG, payload).await?;
+        let buf = self.recv_exact(&mut s, 1).await?;
+        Ok(buf[0])
+    }
+
+    // ── Streaming (U64 only) ──────────────────────────────────────
+
+    /// `CMD_VICSTREAM_ON` / `CMD_AUDIOSTREAM_ON` / `CMD_DEBUGSTREAM_ON`
+    ///
+    /// Start a stream of the given `kind`.
+    /// `buffer_size`: optional frame/buffer size hint (0 = device default).
+    /// `name`: optional stream name / destination hint (may be empty).
+    ///
+    /// Note: starting VIC stream automatically stops DEBUG stream, and
+    /// vice-versa, mirroring the C++ logic.
+    pub async fn stream_start(
+        &self,
+        kind: StreamKind,
+        buffer_size: u16,
+        name: &str,
+    ) -> Port64Result<()> {
+        let cmd = match kind {
+            StreamKind::Vic => CMD_VICSTREAM_ON,
+            StreamKind::Audio => CMD_AUDIOSTREAM_ON,
+            StreamKind::Debug => CMD_DEBUGSTREAM_ON,
+        };
+        // Payload: [buf_lo, buf_hi, name_bytes…]
+        let mut payload = Vec::with_capacity(2 + name.len());
+        payload.extend_from_slice(&buffer_size.to_le_bytes());
+        payload.extend_from_slice(name.as_bytes());
+
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, cmd, &payload).await
+    }
+
+    /// `CMD_VICSTREAM_OFF` / `CMD_AUDIOSTREAM_OFF` / `CMD_DEBUGSTREAM_OFF`
+    pub async fn stream_stop(&self, kind: StreamKind) -> Port64Result<()> {
+        let cmd = match kind {
+            StreamKind::Vic => CMD_VICSTREAM_OFF,
+            StreamKind::Audio => CMD_AUDIOSTREAM_OFF,
+            StreamKind::Debug => CMD_DEBUGSTREAM_OFF,
+        };
+        let mut s = self.open().await?;
+        self.send_cmd(&mut s, cmd, &[]).await
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Convenience free functions
+//
+//  These are thin wrappers around Port64Client for callers that want
+//  a fire-and-forget style without constructing a client explicitly.
+//  Used by memory_editor.rs via `port64::write_dma(...)`.
+// ─────────────────────────────────────────────────────────────────
+
+/// Fire-and-forget `dma_write`.
+pub async fn write_dma(
+    host: String,
+    password: Option<String>,
+    address: u16,
+    data: Vec<u8>,
+) -> Result<(), String> {
+    Port64Client::new(host, password)
+        .dma_write(address, &data)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Fire-and-forget `dma_jump`.
+pub async fn write_dma_jump(
+    host: String,
+    password: Option<String>,
+    address: u16,
+    data: Vec<u8>,
+) -> Result<(), String> {
+    Port64Client::new(host, password)
+        .dma_jump(address, &data)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Fire-and-forget `reu_write`.
+pub async fn write_reu(
+    host: String,
+    password: Option<String>,
+    offset: u32,
+    data: Vec<u8>,
+) -> Result<(), String> {
+    Port64Client::new(host, password)
+        .reu_write(offset, &data)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Fire-and-forget `kernal_write`.
+pub async fn write_kernal(
+    host: String,
+    password: Option<String>,
+    rom_data: Vec<u8>,
+) -> Result<(), String> {
+    Port64Client::new(host, password)
+        .kernal_write(&rom_data)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Query flash geometry (page_size, page_count).
+pub async fn flash_info(host: String, password: Option<String>) -> Result<(u32, u32), String> {
+    Port64Client::new(host, password)
+        .flash_geometry()
+        .await
+        .map(|g| (g.page_size, g.page_count))
+        .map_err(|e| e.to_string())
+}
+
+/// Read one flash page by index.
+pub async fn flash_page(
+    host: String,
+    password: Option<String>,
+    page: u32,
+) -> Result<(u32, Vec<u8>), String> {
+    Port64Client::new(host, password)
+        .flash_read_page(page)
+        .await
+        .map(|data| (page, data))
+        .map_err(|e| e.to_string())
+}

--- a/src/sid_monitor.rs
+++ b/src/sid_monitor.rs
@@ -1,0 +1,1418 @@
+//! Live hardware register monitor for the Commodore 64.
+//!
+//! Polls C64 memory via the Ultimate64 REST API and decodes the raw register
+//! values into human-readable form for three hardware chips:
+//!
+//! - **SID** ($D400 / $D500 / $D440) — 3 voices, filter, envelope, waveforms
+//! - **VIC-II** ($D000) — video, sprites, raster, colour registers
+//! - **CIA #1 / #2** ($DC00 / $DD00) — timers, TOD clock, port states
+//!
+
+use iced::{
+    Element, Length, Subscription, Task,
+    widget::{Column, Space, button, column, container, pick_list, row, rule, scrollable, text},
+};
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
+use ultimate64::Rest;
+
+// ─────────────────────────────────────────────────────────────────
+//  Hardware constants
+// ─────────────────────────────────────────────────────────────────
+
+/// Default poll interval in milliseconds
+const POLL_MS: u64 = 250;
+
+/// REST read timeout
+const TIMEOUT_SECS: u64 = 3;
+
+/// PAL clock frequency used for SID frequency → Hz conversion
+const PAL_CLOCK: f64 = 985_248.4;
+const NTSC_CLOCK: f64 = 1_022_727.1;
+
+/// SID register block size (29 registers, padded to 32)
+const SID_REG_LEN: u16 = 0x1C;
+
+/// VIC-II base address and register count
+const VIC_BASE: u16 = 0xD000;
+const VIC_REG_LEN: u16 = 0x40;
+
+/// CIA register block size
+const CIA_REG_LEN: u16 = 0x10;
+const CIA1_BASE: u16 = 0xDC00;
+const CIA2_BASE: u16 = 0xDD00;
+
+/// C64 colour palette (Colodore, 16 entries)
+const PALETTE: [(u8, u8, u8, &str); 16] = [
+    (0x00, 0x00, 0x00, "Black"),
+    (0xEF, 0xEF, 0xEF, "White"),
+    (0x8D, 0x2F, 0x34, "Red"),
+    (0x6A, 0xD4, 0xCD, "Cyan"),
+    (0x98, 0x35, 0xA4, "Purple"),
+    (0x4C, 0xB4, 0x42, "Green"),
+    (0x2C, 0x29, 0xB1, "Blue"),
+    (0xEF, 0xEF, 0x5D, "Yellow"),
+    (0x98, 0x4E, 0x20, "Orange"),
+    (0x5B, 0x38, 0x00, "Brown"),
+    (0xD1, 0x67, 0x6D, "Light Red"),
+    (0x4A, 0x4A, 0x4A, "Dark Grey"),
+    (0x7B, 0x7B, 0x7B, "Mid Grey"),
+    (0x9F, 0xEF, 0x93, "Light Green"),
+    (0x6D, 0x6A, 0xEF, "Light Blue"),
+    (0xB2, 0xB2, 0xB2, "Light Grey"),
+];
+
+/// ADSR timing table (index = nibble value, value = human label)
+const ADSR_TIME: [&str; 16] = [
+    "2ms", "8ms", "16ms", "24ms", "38ms", "56ms", "68ms", "80ms", "100ms", "250ms", "500ms",
+    "800ms", "1s", "3s", "5s", "8s",
+];
+
+// ─────────────────────────────────────────────────────────────────
+//  Types
+// ─────────────────────────────────────────────────────────────────
+
+/// Which panel is active
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MonitorPanel {
+    #[default]
+    Sid,
+    Vic,
+    Cia,
+}
+
+impl std::fmt::Display for MonitorPanel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MonitorPanel::Sid => write!(f, "SID"),
+            MonitorPanel::Vic => write!(f, "VIC-II"),
+            MonitorPanel::Cia => write!(f, "CIA"),
+        }
+    }
+}
+
+/// Which SID chip to read (address)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SidAddress {
+    #[default]
+    D400, // SID #1 (always present)
+    D500, // SID #2 — most common stereo address (Prophet64, HardSID)
+    D420, // SID #2 — alternative (SidCard compatible)
+    DE00, // SID #2 — I/O expansion area
+    DF00, // SID #2 — I/O expansion area alt
+    D440, // SID #3
+}
+
+impl SidAddress {
+    pub fn base(self) -> u16 {
+        match self {
+            SidAddress::D400 => 0xD400,
+            SidAddress::D500 => 0xD500,
+            SidAddress::D420 => 0xD420,
+            SidAddress::DE00 => 0xDE00,
+            SidAddress::DF00 => 0xDF00,
+            SidAddress::D440 => 0xD440,
+        }
+    }
+}
+
+impl std::fmt::Display for SidAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "${:04X}", self.base())
+    }
+}
+
+/// TV standard — affects SID frequency → Hz conversion
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TvStandard {
+    #[default]
+    Pal,
+    Ntsc,
+}
+
+impl std::fmt::Display for TvStandard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TvStandard::Pal => write!(f, "PAL"),
+            TvStandard::Ntsc => write!(f, "NTSC"),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Decoded SID state (one chip)
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+struct SidVoice {
+    freq_reg: u16,
+    pw_reg: u16,
+    control: u8,
+    attack: u8,
+    decay: u8,
+    sustain: u8,
+    release: u8,
+}
+
+impl SidVoice {
+    fn from_regs(r: &[u8], base: usize) -> Self {
+        Self {
+            freq_reg: (r[base] as u16) | ((r[base + 1] as u16) << 8),
+            pw_reg: (r[base + 2] as u16) | ((r[base + 3] as u16 & 0x0F) << 8),
+            control: r[base + 4],
+            attack: r[base + 5] >> 4,
+            decay: r[base + 5] & 0x0F,
+            sustain: r[base + 6] >> 4,
+            release: r[base + 6] & 0x0F,
+        }
+    }
+
+    fn freq_hz(&self, clock: f64) -> f64 {
+        self.freq_reg as f64 * clock / 16_777_216.0
+    }
+
+    fn note_name(&self, clock: f64) -> String {
+        let hz = self.freq_hz(clock);
+        if hz < 16.0 {
+            return "---".into();
+        }
+        let midi = (69.0 + 12.0 * (hz / 440.0).log2()).round() as i32;
+        let names = [
+            "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+        ];
+        let note = ((midi % 12) + 12) as usize % 12;
+        let oct = (midi / 12) - 1;
+        format!("{}{}", names[note], oct)
+    }
+
+    fn waveform(&self) -> String {
+        let c = self.control;
+        let mut w = Vec::new();
+        if c & 0x80 != 0 {
+            w.push("NOISE");
+        }
+        if c & 0x40 != 0 {
+            w.push("PULSE");
+        }
+        if c & 0x20 != 0 {
+            w.push("SAW");
+        }
+        if c & 0x10 != 0 {
+            w.push("TRI");
+        }
+        if w.is_empty() {
+            "---".into()
+        } else {
+            w.join("+")
+        }
+    }
+
+    fn gate(&self) -> bool {
+        self.control & 0x01 != 0
+    }
+    fn sync(&self) -> bool {
+        self.control & 0x02 != 0
+    }
+    fn ring(&self) -> bool {
+        self.control & 0x04 != 0
+    }
+    fn test(&self) -> bool {
+        self.control & 0x08 != 0
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct SidState {
+    voices: [SidVoice; 3],
+    fc_lo: u8,    // filter cutoff low 3 bits
+    fc_hi: u8,    // filter cutoff high 8 bits
+    res_filt: u8, // resonance + filter routing
+    mode_vol: u8, // mode flags + volume
+    osc3: u8,     // voice 3 oscillator output (read-only)
+    env3: u8,     // voice 3 envelope output (read-only)
+}
+
+impl SidState {
+    fn from_bytes(r: &[u8]) -> Self {
+        if r.len() < 0x1C {
+            return Self::default();
+        }
+        Self {
+            voices: [
+                SidVoice::from_regs(r, 0x00),
+                SidVoice::from_regs(r, 0x07),
+                SidVoice::from_regs(r, 0x0E),
+            ],
+            fc_lo: r[0x15],
+            fc_hi: r[0x16],
+            res_filt: r[0x17],
+            mode_vol: r[0x18],
+            osc3: if r.len() > 0x1B { r[0x1B] } else { 0 },
+            env3: if r.len() > 0x1C { r[0x1C] } else { 0 },
+        }
+    }
+
+    fn filter_cutoff(&self) -> u16 {
+        (self.fc_lo as u16 & 0x07) | ((self.fc_hi as u16) << 3)
+    }
+
+    fn filter_cutoff_hz(&self, clock: f64) -> f64 {
+        // Approximation: fc_hz ≈ (cutoff / 2047) * (clock / 20)
+        (self.filter_cutoff() as f64 / 2047.0) * (clock / 20.0)
+    }
+
+    fn resonance(&self) -> u8 {
+        self.res_filt >> 4
+    }
+    fn filt_ex(&self) -> bool {
+        self.res_filt & 0x01 != 0
+    }
+    fn filt_1(&self) -> bool {
+        self.res_filt & 0x02 != 0
+    }
+    fn filt_2(&self) -> bool {
+        self.res_filt & 0x04 != 0
+    }
+    fn filt_3(&self) -> bool {
+        self.res_filt & 0x08 != 0
+    }
+    fn volume(&self) -> u8 {
+        self.mode_vol & 0x0F
+    }
+    fn lp(&self) -> bool {
+        self.mode_vol & 0x10 != 0
+    }
+    fn bp(&self) -> bool {
+        self.mode_vol & 0x20 != 0
+    }
+    fn hp(&self) -> bool {
+        self.mode_vol & 0x40 != 0
+    }
+    fn mute_v3(&self) -> bool {
+        self.mode_vol & 0x80 != 0
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Decoded VIC-II state
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+struct VicState {
+    raw: Vec<u8>,
+}
+
+impl VicState {
+    fn from_bytes(r: Vec<u8>) -> Self {
+        Self { raw: r }
+    }
+
+    fn byte(&self, offset: usize) -> u8 {
+        self.raw.get(offset).copied().unwrap_or(0)
+    }
+
+    fn raster(&self) -> u16 {
+        let hi = if self.byte(0x11) & 0x80 != 0 {
+            0x100
+        } else {
+            0
+        };
+        hi | self.byte(0x12) as u16
+    }
+
+    fn border_colour(&self) -> u8 {
+        self.byte(0x20) & 0x0F
+    }
+    fn bg_colour(&self) -> u8 {
+        self.byte(0x21) & 0x0F
+    }
+    fn screen_enabled(&self) -> bool {
+        self.byte(0x11) & 0x10 != 0
+    }
+    fn bitmap_mode(&self) -> bool {
+        self.byte(0x11) & 0x20 != 0
+    }
+    fn ecm_mode(&self) -> bool {
+        self.byte(0x11) & 0x40 != 0
+    }
+    fn mcm_mode(&self) -> bool {
+        self.byte(0x16) & 0x10 != 0
+    }
+    fn sprites_enabled(&self) -> u8 {
+        self.byte(0x15)
+    }
+
+    fn video_bank(&self) -> u8 {
+        3 - (self.byte(0x18) >> 4)
+    } // CIA2 port A inverted
+    fn char_base(&self) -> u16 {
+        let ptr = (self.byte(0x18) >> 1) & 0x07;
+        (self.video_bank() as u16 * 0x4000) + (ptr as u16 * 0x0800)
+    }
+    fn screen_base(&self) -> u16 {
+        let ptr = self.byte(0x18) >> 4;
+        (self.video_bank() as u16 * 0x4000) + (ptr as u16 * 0x0400)
+    }
+
+    fn colour_name(index: u8) -> &'static str {
+        PALETTE
+            .get(index as usize & 0x0F)
+            .map(|p| p.3)
+            .unwrap_or("?")
+    }
+
+    fn colour_rgb(index: u8) -> iced::Color {
+        let (r, g, b, _) = PALETTE[index as usize & 0x0F];
+        iced::Color::from_rgb(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Decoded CIA state
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default)]
+struct CiaState {
+    raw: Vec<u8>,
+    base_addr: u16,
+}
+
+impl CiaState {
+    fn from_bytes(raw: Vec<u8>, base: u16) -> Self {
+        Self {
+            raw,
+            base_addr: base,
+        }
+    }
+
+    fn byte(&self, offset: usize) -> u8 {
+        self.raw.get(offset).copied().unwrap_or(0)
+    }
+
+    fn timer_a(&self) -> u16 {
+        (self.byte(0x04) as u16) | ((self.byte(0x05) as u16) << 8)
+    }
+    fn timer_b(&self) -> u16 {
+        (self.byte(0x06) as u16) | ((self.byte(0x07) as u16) << 8)
+    }
+
+    fn tod_hours(&self) -> u8 {
+        self.byte(0x0B) & 0x1F
+    }
+    fn tod_minutes(&self) -> u8 {
+        self.byte(0x0A)
+    }
+    fn tod_seconds(&self) -> u8 {
+        self.byte(0x09)
+    }
+    fn tod_tenths(&self) -> u8 {
+        self.byte(0x08)
+    }
+    fn tod_pm(&self) -> bool {
+        self.byte(0x0B) & 0x80 != 0
+    }
+
+    fn tod_string(&self) -> String {
+        // BCD decoding
+        let bcd = |v: u8| ((v >> 4) * 10 + (v & 0x0F)) as u32;
+        format!(
+            "{:02}:{:02}:{:02}.{} {}",
+            bcd(self.tod_hours()),
+            bcd(self.tod_minutes()),
+            bcd(self.tod_seconds()),
+            bcd(self.tod_tenths()),
+            if self.tod_pm() { "PM" } else { "AM" }
+        )
+    }
+
+    fn icr(&self) -> u8 {
+        self.byte(0x0D)
+    }
+    fn cra(&self) -> u8 {
+        self.byte(0x0E)
+    }
+    fn crb(&self) -> u8 {
+        self.byte(0x0F)
+    }
+
+    fn timer_a_running(&self) -> bool {
+        self.cra() & 0x01 != 0
+    }
+    fn timer_b_running(&self) -> bool {
+        self.crb() & 0x01 != 0
+    }
+
+    fn irq_set(&self) -> bool {
+        self.icr() & 0x80 != 0
+    }
+    fn irq_ta(&self) -> bool {
+        self.icr() & 0x01 != 0
+    }
+    fn irq_tb(&self) -> bool {
+        self.icr() & 0x02 != 0
+    }
+    fn irq_tod(&self) -> bool {
+        self.icr() & 0x04 != 0
+    }
+    fn irq_sp(&self) -> bool {
+        self.icr() & 0x08 != 0
+    }
+    fn irq_flag(&self) -> bool {
+        self.icr() & 0x10 != 0
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Messages
+// ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub enum SidMonitorMessage {
+    // Panel navigation
+    PanelChanged(MonitorPanel),
+
+    // SID settings
+    SidAddressChanged(SidAddress),
+    TvStandardChanged(TvStandard),
+
+    // Watch control
+    ToggleWatch,
+    Tick,
+
+    // Data received
+    SidDataReceived(Result<Vec<u8>, String>),
+    VicDataReceived(Result<Vec<u8>, String>),
+    CiaDataReceived(Result<(Vec<u8>, Vec<u8>), String>),
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  State
+// ─────────────────────────────────────────────────────────────────
+
+pub struct SidMonitor {
+    // Settings
+    active_panel: MonitorPanel,
+    sid_address: SidAddress,
+    tv_standard: TvStandard,
+
+    // Live data
+    sid: Option<SidState>,
+    vic: Option<VicState>,
+    cia1: Option<CiaState>,
+    cia2: Option<CiaState>,
+
+    // Watch
+    watch_active: bool,
+    is_loading: bool,
+    poll_count: u64, // how many polls have completed
+    status: String,
+}
+
+impl SidMonitor {
+    pub fn new() -> Self {
+        Self {
+            active_panel: MonitorPanel::Sid,
+            sid_address: SidAddress::D400,
+            tv_standard: TvStandard::Pal,
+            sid: None,
+            vic: None,
+            cia1: None,
+            cia2: None,
+            watch_active: false,
+            is_loading: false,
+            poll_count: 0,
+            status: String::new(),
+        }
+    }
+
+    pub fn subscription(&self) -> Subscription<SidMonitorMessage> {
+        if self.watch_active {
+            iced::time::every(std::time::Duration::from_millis(POLL_MS))
+                .map(|_| SidMonitorMessage::Tick)
+        } else {
+            Subscription::none()
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        message: SidMonitorMessage,
+        connection: Option<Arc<TokioMutex<Rest>>>,
+    ) -> Task<SidMonitorMessage> {
+        match message {
+            SidMonitorMessage::PanelChanged(p) => {
+                self.active_panel = p;
+                Task::none()
+            }
+
+            SidMonitorMessage::SidAddressChanged(addr) => {
+                self.sid_address = addr;
+                self.sid = None;
+                Task::none()
+            }
+
+            SidMonitorMessage::TvStandardChanged(tv) => {
+                self.tv_standard = tv;
+                Task::none()
+            }
+
+            SidMonitorMessage::ToggleWatch => {
+                self.watch_active = !self.watch_active;
+                self.status = if self.watch_active {
+                    format!("Live — polling every {} ms", POLL_MS)
+                } else {
+                    "Stopped".into()
+                };
+                // Trigger an immediate read when starting
+                if self.watch_active {
+                    return self.update(SidMonitorMessage::Tick, connection);
+                }
+                Task::none()
+            }
+
+            SidMonitorMessage::Tick => {
+                if self.is_loading {
+                    return Task::none();
+                }
+                let Some(conn) = connection else {
+                    return Task::none();
+                };
+                self.is_loading = true;
+
+                match self.active_panel {
+                    MonitorPanel::Sid => {
+                        let addr = self.sid_address.base();
+                        Task::perform(
+                            async move { read_bytes(conn, addr, SID_REG_LEN).await },
+                            SidMonitorMessage::SidDataReceived,
+                        )
+                    }
+                    MonitorPanel::Vic => Task::perform(
+                        async move { read_bytes(conn, VIC_BASE, VIC_REG_LEN).await },
+                        SidMonitorMessage::VicDataReceived,
+                    ),
+                    MonitorPanel::Cia => Task::perform(
+                        async move {
+                            let r1 = read_bytes(conn.clone(), CIA1_BASE, CIA_REG_LEN).await;
+                            let r2 = read_bytes(conn, CIA2_BASE, CIA_REG_LEN).await;
+                            match (r1, r2) {
+                                (Ok(a), Ok(b)) => Ok((a, b)),
+                                (Err(e), _) | (_, Err(e)) => Err(e),
+                            }
+                        },
+                        SidMonitorMessage::CiaDataReceived,
+                    ),
+                }
+            }
+
+            SidMonitorMessage::SidDataReceived(result) => {
+                self.is_loading = false;
+                match result {
+                    Ok(data) => {
+                        self.poll_count += 1;
+                        self.sid = Some(SidState::from_bytes(&data));
+                    }
+                    Err(e) => {
+                        self.status = format!("Read error: {}", e);
+                        self.watch_active = false;
+                    }
+                }
+                Task::none()
+            }
+
+            SidMonitorMessage::VicDataReceived(result) => {
+                self.is_loading = false;
+                match result {
+                    Ok(data) => {
+                        self.poll_count += 1;
+                        self.vic = Some(VicState::from_bytes(data));
+                    }
+                    Err(e) => {
+                        self.status = format!("Read error: {}", e);
+                        self.watch_active = false;
+                    }
+                }
+                Task::none()
+            }
+
+            SidMonitorMessage::CiaDataReceived(result) => {
+                self.is_loading = false;
+                match result {
+                    Ok((d1, d2)) => {
+                        self.poll_count += 1;
+                        self.cia1 = Some(CiaState::from_bytes(d1, CIA1_BASE));
+                        self.cia2 = Some(CiaState::from_bytes(d2, CIA2_BASE));
+                    }
+                    Err(e) => {
+                        self.status = format!("Read error: {}", e);
+                        self.watch_active = false;
+                    }
+                }
+                Task::none()
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    //  View
+    // ─────────────────────────────────────────────────────────────
+
+    pub fn view(&self, is_connected: bool, font_size: u32) -> Element<'_, SidMonitorMessage> {
+        let sf = font_size.saturating_sub(2);
+
+        if !is_connected {
+            return container(
+                column![
+                    Space::new().height(Length::Fill),
+                    text("Please connect to your Ultimate64 device first.").size(sf),
+                    Space::new().height(Length::Fill),
+                ]
+                .align_x(iced::Alignment::Center)
+                .width(Length::Fill),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(10)
+            .into();
+        }
+
+        let toolbar = self.view_toolbar(sf);
+        let panel: Element<'_, SidMonitorMessage> = match self.active_panel {
+            MonitorPanel::Sid => self.view_sid(sf),
+            MonitorPanel::Vic => self.view_vic(sf),
+            MonitorPanel::Cia => self.view_cia(sf),
+        };
+
+        container(
+            column![toolbar, rule::horizontal(1), panel]
+                .spacing(8)
+                .width(Length::Fill)
+                .height(Length::Fill),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .padding(10)
+        .into()
+    }
+
+    // ── Toolbar ──────────────────────────────────────────────────
+
+    fn view_toolbar(&self, sf: u32) -> Element<'_, SidMonitorMessage> {
+        let panel_picker = pick_list(
+            vec![MonitorPanel::Sid, MonitorPanel::Vic, MonitorPanel::Cia],
+            Some(self.active_panel),
+            SidMonitorMessage::PanelChanged,
+        )
+        .text_size(sf)
+        .width(Length::Fixed(90.0));
+
+        let watch_btn = button(
+            text(if self.watch_active {
+                "⏹ Stop"
+            } else {
+                "▶ Live"
+            })
+            .size(sf),
+        )
+        .on_press(SidMonitorMessage::ToggleWatch)
+        .style(if self.watch_active {
+            button::primary
+        } else {
+            button::secondary
+        })
+        .padding([5, 12]);
+
+        let poll_label = if self.poll_count > 0 {
+            text(format!("#{}", self.poll_count))
+                .size(sf.saturating_sub(1))
+                .color(iced::Color::from_rgb(0.5, 0.5, 0.5))
+        } else {
+            text("").size(sf)
+        };
+
+        // SID-specific controls
+        let sid_controls: Element<'_, SidMonitorMessage> = if self.active_panel == MonitorPanel::Sid
+        {
+            row![
+                text("SID:").size(sf),
+                pick_list(
+                    vec![
+                        SidAddress::D400,
+                        SidAddress::D500,
+                        SidAddress::D420,
+                        SidAddress::DE00,
+                        SidAddress::DF00,
+                        SidAddress::D440,
+                    ],
+                    Some(self.sid_address),
+                    SidMonitorMessage::SidAddressChanged,
+                )
+                .text_size(sf)
+                .width(Length::Fixed(80.0)),
+                pick_list(
+                    vec![TvStandard::Pal, TvStandard::Ntsc],
+                    Some(self.tv_standard),
+                    SidMonitorMessage::TvStandardChanged,
+                )
+                .text_size(sf)
+                .width(Length::Fixed(65.0)),
+            ]
+            .spacing(8)
+            .align_y(iced::Alignment::Center)
+            .into()
+        } else {
+            Space::new().width(Length::Shrink).into()
+        };
+
+        let status_text = if !self.status.is_empty() {
+            text(&*self.status)
+                .size(sf.saturating_sub(1))
+                .color(iced::Color::from_rgb(0.5, 0.5, 0.6))
+        } else {
+            text("").size(sf)
+        };
+
+        row![
+            panel_picker,
+            Space::new().width(Length::Fixed(12.0)),
+            watch_btn,
+            poll_label,
+            Space::new().width(Length::Fixed(12.0)),
+            sid_controls,
+            Space::new().width(Length::Fill),
+            status_text,
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center)
+        .into()
+    }
+
+    // ── SID panel ────────────────────────────────────────────────
+
+    fn view_sid(&self, sf: u32) -> Element<'_, SidMonitorMessage> {
+        let mf = sf.saturating_sub(1);
+
+        let Some(sid) = &self.sid else {
+            return self.view_placeholder("No SID data yet — press ▶ Live", sf);
+        };
+
+        let clock = match self.tv_standard {
+            TvStandard::Pal => PAL_CLOCK,
+            TvStandard::Ntsc => NTSC_CLOCK,
+        };
+
+        // ── Filter section ───────────────────────────────────────
+        let fc = sid.filter_cutoff();
+        let fc_hz = sid.filter_cutoff_hz(clock);
+        let mut filter_routing = Vec::new();
+        if sid.filt_1() {
+            filter_routing.push("V1");
+        }
+        if sid.filt_2() {
+            filter_routing.push("V2");
+        }
+        if sid.filt_3() {
+            filter_routing.push("V3");
+        }
+        if sid.filt_ex() {
+            filter_routing.push("EXT");
+        }
+        let mut filter_mode = Vec::new();
+        if sid.lp() {
+            filter_mode.push("LP");
+        }
+        if sid.bp() {
+            filter_mode.push("BP");
+        }
+        if sid.hp() {
+            filter_mode.push("HP");
+        }
+
+        let filter_row = container(
+            row![
+                kv("Cutoff", &format!("${:03X}  ({:.0} Hz)", fc, fc_hz), mf),
+                Space::new().width(Length::Fixed(16.0)),
+                kv("Res", &format!("{}", sid.resonance()), mf),
+                Space::new().width(Length::Fixed(16.0)),
+                kv(
+                    "Mode",
+                    &if filter_mode.is_empty() {
+                        "OFF".into()
+                    } else {
+                        filter_mode.join("+")
+                    },
+                    mf
+                ),
+                Space::new().width(Length::Fixed(16.0)),
+                kv(
+                    "Route",
+                    &if filter_routing.is_empty() {
+                        "none".into()
+                    } else {
+                        filter_routing.join(" ")
+                    },
+                    mf
+                ),
+                Space::new().width(Length::Fixed(16.0)),
+                kv("Vol", &format!("{}", sid.volume()), mf),
+                Space::new().width(Length::Fixed(16.0)),
+                kv("MuteV3", &yn(sid.mute_v3()), mf),
+            ]
+            .spacing(4)
+            .align_y(iced::Alignment::Center),
+        )
+        .style(section_style)
+        .padding(8)
+        .width(Length::Fill);
+
+        // ── Voice table ──────────────────────────────────────────
+        let header = voice_header_row(mf);
+
+        let mut voice_rows: Vec<Element<'_, SidMonitorMessage>> = vec![header];
+        for (i, voice) in sid.voices.iter().enumerate() {
+            let hz = voice.freq_hz(clock);
+            let note = voice.note_name(clock);
+
+            let gate_colour = if voice.gate() {
+                iced::Color::from_rgb(0.3, 0.9, 0.3)
+            } else {
+                iced::Color::from_rgb(0.5, 0.5, 0.5)
+            };
+
+            let row_el = row![
+                // Voice number
+                text(format!("V{}", i + 1))
+                    .size(mf)
+                    .width(Length::Fixed(24.0))
+                    .color(iced::Color::from_rgb(0.5, 0.7, 1.0)),
+                // Freq reg + Hz + note
+                text(format!("${:04X}", voice.freq_reg))
+                    .size(mf)
+                    .width(Length::Fixed(54.0)),
+                text(format!("{:7.1}Hz", hz))
+                    .size(mf)
+                    .width(Length::Fixed(80.0)),
+                text(note)
+                    .size(mf)
+                    .width(Length::Fixed(36.0))
+                    .color(iced::Color::from_rgb(0.9, 0.9, 0.4)),
+                // Waveform
+                text(voice.waveform()).size(mf).width(Length::Fixed(90.0)),
+                // PW (only meaningful for PULSE)
+                text(format!("PW ${:03X}", voice.pw_reg))
+                    .size(mf)
+                    .width(Length::Fixed(72.0))
+                    .color(if voice.control & 0x40 != 0 {
+                        iced::Color::WHITE
+                    } else {
+                        iced::Color::from_rgb(0.4, 0.4, 0.4)
+                    }),
+                // ADSR
+                text(format!(
+                    "A:{} D:{} S:{} R:{}",
+                    ADSR_TIME[voice.attack as usize],
+                    ADSR_TIME[voice.decay as usize],
+                    voice.sustain,
+                    ADSR_TIME[voice.release as usize]
+                ))
+                .size(mf)
+                .width(Length::Fixed(200.0)),
+                // Gate
+                text(if voice.gate() { "GATE▲" } else { "GATE▼" })
+                    .size(mf)
+                    .width(Length::Fixed(52.0))
+                    .color(gate_colour),
+                // Modifiers
+                text(format!(
+                    "{}{}{}",
+                    if voice.sync() { "SYNC " } else { "" },
+                    if voice.ring() { "RING " } else { "" },
+                    if voice.test() { "TEST" } else { "" }
+                ))
+                .size(mf),
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center);
+
+            voice_rows.push(row_el.into());
+        }
+
+        // V3 read-back row
+        voice_rows.push(
+            row![
+                text("V3 RAW")
+                    .size(mf.saturating_sub(1))
+                    .color(iced::Color::from_rgb(0.5, 0.5, 0.6))
+                    .width(Length::Fixed(24.0)),
+                text(format!("Osc=${:02X}", sid.osc3))
+                    .size(mf.saturating_sub(1))
+                    .color(iced::Color::from_rgb(0.5, 0.5, 0.6)),
+                Space::new().width(Length::Fixed(8.0)),
+                text(format!("Env=${:02X}", sid.env3))
+                    .size(mf.saturating_sub(1))
+                    .color(iced::Color::from_rgb(0.5, 0.5, 0.6)),
+            ]
+            .spacing(6)
+            .into(),
+        );
+
+        let voices_block = container(Column::with_children(voice_rows).spacing(6))
+            .style(section_style)
+            .padding(8)
+            .width(Length::Fill);
+
+        scrollable(
+            column![
+                text(format!("SID @ {} — {}", self.sid_address, self.tv_standard)).size(sf),
+                rule::horizontal(1),
+                voices_block,
+                rule::horizontal(1),
+                filter_row,
+            ]
+            .spacing(8)
+            .width(Length::Fill),
+        )
+        .height(Length::Fill)
+        .into()
+    }
+
+    // ── VIC-II panel ─────────────────────────────────────────────
+
+    fn view_vic(&self, sf: u32) -> Element<'_, SidMonitorMessage> {
+        let mf = sf.saturating_sub(1);
+
+        let Some(vic) = &self.vic else {
+            return self.view_placeholder("No VIC-II data yet — press ▶ Live", sf);
+        };
+
+        // Screen mode string
+        let mode = match (vic.ecm_mode(), vic.bitmap_mode(), vic.mcm_mode()) {
+            (false, false, false) => "Standard Text",
+            (false, false, true) => "Multicolour Text",
+            (false, true, false) => "Hires Bitmap",
+            (false, true, true) => "Multicolour Bitmap",
+            (true, false, false) => "ECM Text",
+            _ => "Invalid Mode",
+        };
+
+        let screen_row = container(
+            row![
+                kv("Mode", mode, mf),
+                Space::new().width(16),
+                kv("Screen", &yn(vic.screen_enabled()), mf),
+                Space::new().width(16),
+                kv(
+                    "Raster",
+                    &format!("${:03X} ({})", vic.raster(), vic.raster()),
+                    mf
+                ),
+                Space::new().width(16),
+                kv(
+                    "VidBank",
+                    &format!(
+                        "{} (${:04X}–${:04X})",
+                        vic.video_bank(),
+                        vic.video_bank() as u16 * 0x4000,
+                        vic.video_bank() as u16 * 0x4000 + 0x3FFF,
+                    ),
+                    mf
+                ),
+            ]
+            .spacing(8)
+            .align_y(iced::Alignment::Center),
+        )
+        .style(section_style)
+        .padding(8)
+        .width(Length::Fill);
+
+        let memory_row = container(
+            row![
+                kv("Screen RAM", &format!("${:04X}", vic.screen_base()), mf),
+                Space::new().width(16),
+                kv("Char/Bitmap", &format!("${:04X}", vic.char_base()), mf),
+                Space::new().width(16),
+                kv("Mem ptr $D018", &format!("${:02X}", vic.byte(0x18)), mf),
+            ]
+            .spacing(8)
+            .align_y(iced::Alignment::Center),
+        )
+        .style(section_style)
+        .padding(8)
+        .width(Length::Fill);
+
+        // Colour swatches
+        let colour_row = container(
+            row![
+                text("Border:").size(mf).width(Length::Fixed(50.0)),
+                colour_swatch(vic.border_colour(), mf),
+                Space::new().width(16),
+                text("BG0:").size(mf).width(Length::Fixed(36.0)),
+                colour_swatch(vic.bg_colour(), mf),
+                Space::new().width(16),
+                text("BG1:").size(mf).width(Length::Fixed(36.0)),
+                colour_swatch(vic.byte(0x22) & 0x0F, mf),
+                Space::new().width(16),
+                text("BG2:").size(mf).width(Length::Fixed(36.0)),
+                colour_swatch(vic.byte(0x23) & 0x0F, mf),
+                Space::new().width(16),
+                text("BG3:").size(mf).width(Length::Fixed(36.0)),
+                colour_swatch(vic.byte(0x24) & 0x0F, mf),
+            ]
+            .spacing(4)
+            .align_y(iced::Alignment::Center),
+        )
+        .style(section_style)
+        .padding(8)
+        .width(Length::Fill);
+
+        // Sprite summary
+        let spr_enabled = vic.sprites_enabled();
+        let mut spr_rows: Vec<Element<'_, SidMonitorMessage>> = Vec::new();
+        for i in 0..8u8 {
+            if spr_enabled & (1 << i) != 0 {
+                let x_msb = if vic.byte(0x10) & (1 << i) != 0 {
+                    0x100u16
+                } else {
+                    0
+                };
+                let sx = x_msb | vic.byte((i * 2) as usize) as u16;
+                let sy = vic.byte((i * 2 + 1) as usize);
+                let colour = vic.byte(0x27 + i as usize) & 0x0F;
+                let dblx = vic.byte(0x1D) & (1 << i) != 0;
+                let dbly = vic.byte(0x17) & (1 << i) != 0;
+                let mc = vic.byte(0x1C) & (1 << i) != 0;
+                let bgpri = vic.byte(0x1B) & (1 << i) != 0;
+                spr_rows.push(
+                    row![
+                        text(format!("S{}", i))
+                            .size(mf)
+                            .color(iced::Color::from_rgb(0.5, 0.7, 1.0))
+                            .width(Length::Fixed(20.0)),
+                        text(format!("X={:3} Y={:3}", sx, sy))
+                            .size(mf)
+                            .width(Length::Fixed(100.0)),
+                        colour_swatch(colour, mf),
+                        Space::new().width(Length::Fixed(4.0)),
+                        text(format!(
+                            "{}{}{}{}",
+                            if dblx { "2X " } else { "" },
+                            if dbly { "2Y " } else { "" },
+                            if mc { "MC " } else { "" },
+                            if bgpri { "BG" } else { "" },
+                        ))
+                        .size(mf),
+                    ]
+                    .spacing(6)
+                    .align_y(iced::Alignment::Center)
+                    .into(),
+                );
+            }
+        }
+
+        let sprites_block = container(
+            if spr_rows.is_empty() {
+                column![
+                    text("No sprites enabled")
+                        .size(mf)
+                        .color(iced::Color::from_rgb(0.4, 0.4, 0.4))
+                ]
+            } else {
+                column![
+                    text("Active Sprites").size(mf),
+                    Column::with_children(spr_rows).spacing(4),
+                ]
+            }
+            .spacing(6),
+        )
+        .style(section_style)
+        .padding(8)
+        .width(Length::Fill);
+
+        // IRQ / interrupt state
+        let irq_row = container(
+            row![
+                kv("IRQ $D019", &format!("${:02X}", vic.byte(0x19)), mf),
+                Space::new().width(16),
+                kv("IRQ Mask", &format!("${:02X}", vic.byte(0x1A)), mf),
+            ]
+            .spacing(8)
+            .align_y(iced::Alignment::Center),
+        )
+        .style(section_style)
+        .padding(8)
+        .width(Length::Fill);
+
+        scrollable(
+            column![
+                text("VIC-II @ $D000").size(sf),
+                rule::horizontal(1),
+                screen_row,
+                memory_row,
+                colour_row,
+                sprites_block,
+                irq_row,
+            ]
+            .spacing(8)
+            .width(Length::Fill),
+        )
+        .height(Length::Fill)
+        .into()
+    }
+
+    // ── CIA panel ────────────────────────────────────────────────
+
+    fn view_cia(&self, sf: u32) -> Element<'_, SidMonitorMessage> {
+        let mf = sf.saturating_sub(1);
+
+        let (Some(cia1), Some(cia2)) = (&self.cia1, &self.cia2) else {
+            return self.view_placeholder("No CIA data yet — press ▶ Live", sf);
+        };
+
+        scrollable(
+            column![
+                text("CIA Timers & I/O").size(sf),
+                rule::horizontal(1),
+                cia_block_view(cia1, "CIA #1 ($DC00) — Keyboard / Joystick / IRQ", sf, mf),
+                cia_block_view(cia2, "CIA #2 ($DD00) — Serial / NMI / VIC Bank", sf, mf),
+            ]
+            .spacing(12)
+            .width(Length::Fill),
+        )
+        .height(Length::Fill)
+        .into()
+    }
+
+    // ── Placeholder ──────────────────────────────────────────────
+
+    fn view_placeholder<'a>(&self, msg: &'a str, sf: u32) -> Element<'a, SidMonitorMessage> {
+        column![
+            Space::new().height(Length::Fill),
+            text(msg)
+                .size(sf)
+                .color(iced::Color::from_rgb(0.5, 0.5, 0.5)),
+            Space::new().height(Length::Fill),
+        ]
+        .align_x(iced::Alignment::Center)
+        .width(Length::Fill)
+        .into()
+    }
+}
+
+/// Render one CIA chip block. Free function to avoid closure lifetime issues.
+fn cia_block_view(
+    cia: &CiaState,
+    label: &str,
+    sf: u32,
+    mf: u32,
+) -> Element<'static, SidMonitorMessage> {
+    let irq_sources: Vec<&str> = [
+        (cia.irq_ta(), "TimerA"),
+        (cia.irq_tb(), "TimerB"),
+        (cia.irq_tod(), "TOD"),
+        (cia.irq_sp(), "SerPort"),
+        (cia.irq_flag(), "FLAG"),
+    ]
+    .iter()
+    .filter_map(|(active, name)| if *active { Some(*name) } else { None })
+    .collect();
+
+    let label = label.to_string(); // own the string to satisfy 'static
+
+    container(
+        column![
+            text(label).size(sf),
+            rule::horizontal(1),
+            row![
+                kv(
+                    "Timer A",
+                    &format!(
+                        "${:04X}  {}",
+                        cia.timer_a(),
+                        if cia.timer_a_running() {
+                            "▶ RUN"
+                        } else {
+                            "■ STOP"
+                        }
+                    ),
+                    mf
+                ),
+                Space::new().width(16),
+                kv("CRA", &format!("${:02X}", cia.cra()), mf),
+            ]
+            .spacing(8),
+            row![
+                kv(
+                    "Timer B",
+                    &format!(
+                        "${:04X}  {}",
+                        cia.timer_b(),
+                        if cia.timer_b_running() {
+                            "▶ RUN"
+                        } else {
+                            "■ STOP"
+                        }
+                    ),
+                    mf
+                ),
+                Space::new().width(16),
+                kv("CRB", &format!("${:02X}", cia.crb()), mf),
+            ]
+            .spacing(8),
+            kv("TOD", &cia.tod_string(), mf),
+            kv(
+                "ICR",
+                &format!(
+                    "${:02X}  IRQ:{}",
+                    cia.icr(),
+                    if cia.irq_set() {
+                        if irq_sources.is_empty() {
+                            "SET".into()
+                        } else {
+                            irq_sources.join("+")
+                        }
+                    } else {
+                        "clear".into()
+                    }
+                ),
+                mf
+            ),
+            row![
+                kv("Port A", &format!("${:02X}", cia.byte(0x00)), mf),
+                Space::new().width(16),
+                kv("Dir A", &format!("${:02X}", cia.byte(0x02)), mf),
+                Space::new().width(16),
+                kv("Port B", &format!("${:02X}", cia.byte(0x01)), mf),
+                Space::new().width(16),
+                kv("Dir B", &format!("${:02X}", cia.byte(0x03)), mf),
+            ]
+            .spacing(8),
+        ]
+        .spacing(6)
+        .padding(8),
+    )
+    .style(section_style)
+    .width(Length::Fill)
+    .into()
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Small view helpers
+// ─────────────────────────────────────────────────────────────────
+
+/// Key–value pair rendered as "KEY  value"
+fn kv<'a>(key: &str, value: &str, font_size: u32) -> Element<'a, SidMonitorMessage> {
+    row![
+        text(format!("{}: ", key))
+            .size(font_size)
+            .color(iced::Color::from_rgb(0.6, 0.6, 0.7)),
+        text(value.to_string()).size(font_size),
+    ]
+    .spacing(0)
+    .align_y(iced::Alignment::Center)
+    .into()
+}
+
+fn yn(b: bool) -> String {
+    if b { "Yes".into() } else { "No".into() }
+}
+
+/// Coloured square swatch + colour name
+fn colour_swatch<M: Clone + 'static>(index: u8, font_size: u32) -> Element<'static, M> {
+    let (r, g, b, name) = PALETTE[index as usize & 0x0F];
+    let rgb = iced::Color::from_rgb(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0);
+    row![
+        container(Space::new().width(14).height(14)).style(move |_: &iced::Theme| {
+            container::Style {
+                background: Some(iced::Background::Color(rgb)),
+                border: iced::Border {
+                    color: iced::Color::from_rgb(0.3, 0.3, 0.3),
+                    width: 1.0,
+                    radius: 2.0.into(),
+                },
+                ..Default::default()
+            }
+        }),
+        text(format!("{} ({})", name, index)).size(font_size),
+    ]
+    .spacing(4)
+    .align_y(iced::Alignment::Center)
+    .into()
+}
+
+/// Column header row for the voice table
+fn voice_header_row<M: 'static>(font_size: u32) -> Element<'static, M> {
+    let dim = iced::Color::from_rgb(0.45, 0.45, 0.55);
+    row![
+        text("").size(font_size).width(Length::Fixed(24.0)),
+        text("Freq")
+            .size(font_size)
+            .color(dim)
+            .width(Length::Fixed(54.0)),
+        text("Hz")
+            .size(font_size)
+            .color(dim)
+            .width(Length::Fixed(80.0)),
+        text("Note")
+            .size(font_size)
+            .color(dim)
+            .width(Length::Fixed(36.0)),
+        text("Waveform")
+            .size(font_size)
+            .color(dim)
+            .width(Length::Fixed(90.0)),
+        text("PulseW")
+            .size(font_size)
+            .color(dim)
+            .width(Length::Fixed(72.0)),
+        text("ADSR")
+            .size(font_size)
+            .color(dim)
+            .width(Length::Fixed(200.0)),
+        text("Gate")
+            .size(font_size)
+            .color(dim)
+            .width(Length::Fixed(52.0)),
+        text("Mods").size(font_size).color(dim),
+    ]
+    .spacing(6)
+    .into()
+}
+
+fn section_style(_theme: &iced::Theme) -> container::Style {
+    container::Style {
+        background: Some(iced::Background::Color(iced::Color::from_rgba(
+            1.0, 1.0, 1.0, 0.04,
+        ))),
+        border: iced::Border {
+            color: iced::Color::from_rgba(1.0, 1.0, 1.0, 0.10),
+            width: 1.0,
+            radius: 4.0.into(),
+        },
+        ..Default::default()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+//  Async REST helper
+// ─────────────────────────────────────────────────────────────────
+
+async fn read_bytes(
+    connection: Arc<TokioMutex<Rest>>,
+    address: u16,
+    length: u16,
+) -> Result<Vec<u8>, String> {
+    let result = tokio::time::timeout(
+        tokio::time::Duration::from_secs(TIMEOUT_SECS),
+        tokio::task::spawn_blocking(move || {
+            let conn = connection.blocking_lock();
+            conn.read_mem(address, length)
+                .map_err(|e| format!("read_mem failed: {}", e))
+        }),
+    )
+    .await;
+    match result {
+        Ok(Ok(data)) => data,
+        Ok(Err(e)) => Err(format!("Task error: {}", e)),
+        Err(_) => Err("Read timed out — device may be offline".to_string()),
+    }
+}


### PR DESCRIPTION
Introduces port64.rs, a async TCP client wrapping all 21 commands from socket_dma.cc (dma_write, reu_write, kernal_write, flash_read_page, streaming, and more) with authentication handled automatically. 
Extends the memory editor with REU address space support, DMA write/jump, Kernal ROM replacement, a flash page inspector, undo/redo stack, live watch mode, and bookmarks. 
Adds sid_monitor.rs, a new MONITOR tab that polls and decodes SID registers (frequency→Hz→note, ADSR timing, waveforms), VIC-II (screen mode, sprites, colour swatches), and both CIA chips (timers, TOD clock, IRQ sources) at 250 ms. new tab, new subscriptions, and Cmd+Z/Cmd+Shift+Z undo/redo shortcuts.