### PR TITLE
Add window title, persist last tab, Eject A+B, Run last

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -526,6 +526,34 @@ pub async fn upload_mount_disk_async(
 }
 
 /// Upload bytes to a runner endpoint (run_crt, run_prg, sidplay).
+/// Remove the disk image currently mounted on the specified drive.
+///
+/// `drive` is `"a"` or `"b"`. Maps to the device's
+/// `PUT /v1/drives/<drive>:remove` endpoint. The call is idempotent — an
+/// empty drive returns 200 OK without error, so callers can always-fire it
+/// to "ensure empty" without checking first.
+pub async fn unmount_disk_async(
+    host: &str,
+    drive: &str,
+    password: Option<&str>,
+) -> Result<(), String> {
+    let url = format!("{}/v1/drives/{}:remove", host, drive);
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let req = crate::net_utils::with_password(client.put(&url), password);
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("unmount Drive {}: {}", drive.to_uppercase(), e))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "unmount Drive {}: HTTP {}",
+            drive.to_uppercase(),
+            resp.status()
+        ));
+    }
+    Ok(())
+}
+
 pub async fn upload_runner_async(
     host: &str,
     runner: &str,

--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -178,6 +178,34 @@ impl DriveOption {
     }
 }
 
+/// Snapshot of the last successful "run / mount / play" so the `↪ Run last`
+/// toolbar button can re-fire the same action. Updated by the file-browser's
+/// run/mount handlers and read by main.rs through [`FileBrowser::last_run`].
+#[derive(Debug, Clone)]
+pub enum LastRun {
+    Prg(PathBuf),
+    Crt(PathBuf),
+    Sid(PathBuf),
+    Disk { path: PathBuf, drive: String },
+}
+
+impl LastRun {
+    pub fn path(&self) -> &PathBuf {
+        match self {
+            LastRun::Prg(p) | LastRun::Crt(p) | LastRun::Sid(p) => p,
+            LastRun::Disk { path, .. } => path,
+        }
+    }
+
+    pub fn basename(&self) -> String {
+        self.path()
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("file")
+            .to_string()
+    }
+}
+
 pub struct FileBrowser {
     current_directory: PathBuf,
     files: Vec<FileEntry>,
@@ -234,6 +262,9 @@ pub struct FileBrowser {
     /// + Cancel) directly under the row whose path matches. Right-click on
     /// a folder row sets this; clicking either action clears it.
     context_menu_for: Option<PathBuf>,
+    /// Most recent successful run / mount — populated by the run/mount
+    /// handlers below. Drives the `↪ Run last` toolbar button in main.rs.
+    last_run: Option<LastRun>,
 }
 
 const FAVORITES_FILE: &str = "local_favorites.json";
@@ -280,6 +311,7 @@ impl FileBrowser {
             quick_search_buffer: String::new(),
             quick_search_at: None,
             path_input: initial_dir.to_string_lossy().to_string(),
+            last_run: None,
         };
         browser.load_directory(&initial_dir);
         browser
@@ -460,6 +492,14 @@ impl FileBrowser {
             }
             FileBrowserMessage::RunDisk(path, drive) => {
                 if connection.is_some() {
+                    // Record as "last run" before the drive-check round-trip
+                    // — the user clicked Run, so this is what they meant
+                    // regardless of whether the device side ultimately
+                    // succeeds.
+                    self.last_run = Some(LastRun::Disk {
+                        path: path.clone(),
+                        drive: drive.clone(),
+                    });
                     let action = PendingDriveAction::Run(path, drive);
                     return Task::done(FileBrowserMessage::CheckDriveBeforeAction(action));
                 } else {
@@ -482,6 +522,18 @@ impl FileBrowser {
             }
             FileBrowserMessage::LoadAndRun(path) => {
                 if let Some(conn) = connection {
+                    // Record as "last run" — extension drives which variant
+                    // we'll re-fire when the user later hits "↪ Run last".
+                    self.last_run = match path
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.to_lowercase())
+                        .as_deref()
+                    {
+                        Some("prg") => Some(LastRun::Prg(path.clone())),
+                        Some("crt") => Some(LastRun::Crt(path.clone())),
+                        _ => self.last_run.take(), // unknown ext → keep previous
+                    };
                     self.status_message = Some(format!(
                         "Loading {}...",
                         path.file_name().unwrap_or_default().to_string_lossy()
@@ -861,6 +913,7 @@ impl FileBrowser {
 
             FileBrowserMessage::PlaySid(path) => {
                 if let (Some(_host), Some(conn)) = (host.clone(), connection.clone()) {
+                    self.last_run = Some(LastRun::Sid(path.clone()));
                     Task::perform(
                         async move {
                             let data = tokio::fs::read(&path)
@@ -1356,6 +1409,12 @@ impl FileBrowser {
     #[allow(dead_code)]
     pub fn get_selected_file(&self) -> Option<&PathBuf> {
         self.selected_file.as_ref()
+    }
+
+    /// Most-recent successful run / mount, used by main.rs to drive the
+    /// `↪ Run last` toolbar button label + dispatch.
+    pub fn last_run(&self) -> Option<&LastRun> {
+        self.last_run.as_ref()
     }
 
     pub fn filter(&self) -> &str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,6 +326,12 @@ pub enum Message {
     PoweroffMachine,
     MenuButton,
     MachineCommandCompleted(Result<String, String>),
+    /// Eject the disk image from both Drive A and Drive B.
+    EjectAllDrives,
+    EjectCompleted(Result<String, String>),
+    /// Re-fire whatever PRG/CRT/SID/disk the local file browser most
+    /// recently ran. No-op if no run has happened in this session.
+    RunLast,
 
     // Settings
     DefaultSongDurationChanged(String),
@@ -449,7 +455,9 @@ impl DropAction {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// Serialize/Deserialize so the active tab can be persisted in settings.json
+// and restored on next launch — see `Preferences::last_active_tab`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Tab {
     DualPaneBrowser,
     MusicPlayer,
@@ -612,7 +620,12 @@ impl Ultimate64Browser {
         });
 
         let mut app = Self {
-            active_tab: Tab::DualPaneBrowser,
+            // Restore the tab the user closed in last session, or fall back
+            // to the file browser for first-time launches.
+            active_tab: settings
+                .preferences
+                .last_active_tab
+                .unwrap_or(Tab::DualPaneBrowser),
             left_browser,
             remote_browser: RemoteBrowser::new(),
             active_pane: Pane::Left,
@@ -692,13 +705,16 @@ impl Ultimate64Browser {
             return "Ultimate64 Video Stream".to_string();
         }
         if Some(window_id) == self.main_window_id {
-            // Main window title
-            let connection_status = if self.status.connected {
-                format!(" - Connected to {}", self.settings.connection.host)
+            // Format: "Ultimate64 Manager — <host> · <tab>"  when connected,
+            //         "Ultimate64 Manager · Disconnected · <tab>"  otherwise.
+            // The tab name on the tail means people running multiple instances
+            // (one per device) can tell at a glance which window is which.
+            let location = if self.status.connected {
+                self.settings.connection.host.as_str()
             } else {
-                " - Disconnected".to_string()
+                "Disconnected"
             };
-            return format!("Ultimate64 Manager v{}{}", APP_VERSION, connection_status);
+            return format!("Ultimate64 Manager — {} · {}", location, self.active_tab);
         }
         // Fallback
         "Ultimate64 Manager".to_string()
@@ -795,6 +811,13 @@ impl Ultimate64Browser {
             Message::TabSelected(tab) => {
                 log::debug!("Tab selected: {:?}", tab);
                 self.active_tab = tab;
+                // Remember the choice so the next launch opens on the same
+                // tab. A failed disk write is logged but never blocks the
+                // UI — losing a single tab preference is not worth a popup.
+                self.settings.preferences.last_active_tab = Some(tab);
+                if let Err(e) = self.settings.save() {
+                    log::warn!("Could not save settings after tab switch: {}", e);
+                }
                 // Auto-load latest entries when Assembly64 tab is first opened.
                 // Also kick off a background refresh of the dropdown
                 // presets and category map (one-shot per session).
@@ -2754,6 +2777,66 @@ impl Ultimate64Browser {
                 Task::none()
             }
 
+            Message::EjectAllDrives => {
+                let host_url = format!("http://{}", self.settings.connection.host);
+                let password = self.settings.connection.password.clone();
+                // Fire both unmount calls in parallel; the device handles
+                // them independently. Each has its own 5s REST timeout
+                // baked into the client, so the whole op is bounded.
+                let host_a = host_url.clone();
+                let pwd_a = password.clone();
+                let host_b = host_url;
+                let pwd_b = password;
+                Task::perform(
+                    async move {
+                        let (res_a, res_b) = tokio::join!(
+                            api::unmount_disk_async(&host_a, "a", pwd_a.as_deref()),
+                            api::unmount_disk_async(&host_b, "b", pwd_b.as_deref()),
+                        );
+                        match (res_a, res_b) {
+                            (Ok(()), Ok(())) => Ok("Ejected Drives A and B".to_string()),
+                            (Ok(()), Err(e)) => Err(format!("Drive A OK, Drive B failed: {}", e)),
+                            (Err(e), Ok(())) => Err(format!("Drive B OK, Drive A failed: {}", e)),
+                            (Err(a), Err(b)) => Err(format!("Both drives failed: {}; {}", a, b)),
+                        }
+                    },
+                    Message::EjectCompleted,
+                )
+            }
+            Message::EjectCompleted(result) => {
+                self.user_message = Some(match result {
+                    Ok(msg) => UserMessage::Info(msg),
+                    Err(e) => UserMessage::Error(e),
+                });
+                Task::none()
+            }
+            Message::RunLast => {
+                // Re-fire the most recent successful run/mount via the
+                // file_browser's own message bus. Cloning the LastRun is
+                // cheap (PathBuf + small String).
+                let Some(last) = self.left_browser.last_run().cloned() else {
+                    self.user_message = Some(UserMessage::Info("Nothing to re-run yet".into()));
+                    return Task::none();
+                };
+                let msg = match last {
+                    file_browser::LastRun::Prg(p) | file_browser::LastRun::Crt(p) => {
+                        FileBrowserMessage::LoadAndRun(p)
+                    }
+                    file_browser::LastRun::Sid(p) => FileBrowserMessage::PlaySid(p),
+                    file_browser::LastRun::Disk { path, drive } => {
+                        FileBrowserMessage::RunDisk(path, drive)
+                    }
+                };
+                self.left_browser
+                    .update(
+                        msg,
+                        self.connection.clone(),
+                        Some(self.settings.connection.host.clone()),
+                        self.settings.connection.password.clone(),
+                    )
+                    .map(Message::LeftBrowser)
+            }
+
             Message::ResetMachine => {
                 if let Some(conn) = &self.connection {
                     let conn = conn.clone();
@@ -3754,6 +3837,37 @@ impl Ultimate64Browser {
                     .on_press(Message::FnRefresh)
                     .padding([4, 8])
                     .style(crate::styles::nav_button),
+                // Device-control quick actions — gated on connection so an
+                // offline click can't fire a hopeless REST request.
+                button(text("⏏ Eject A+B").size(small))
+                    .on_press_maybe(self.status.connected.then_some(Message::EjectAllDrives),)
+                    .padding([4, 8])
+                    .style(crate::styles::nav_button),
+                // Run last — re-fires the most recent PRG/CRT/SID/disk
+                // the local browser sent. Greys out when nothing's been
+                // run yet OR when the device is offline.
+                tooltip(
+                    button(
+                        text(match self.left_browser.last_run() {
+                            Some(last) => format!("↪ Run last ({})", last.basename()),
+                            None => "↪ Run last".to_string(),
+                        })
+                        .size(small),
+                    )
+                    .on_press_maybe(
+                        (self.status.connected && self.left_browser.last_run().is_some())
+                            .then_some(Message::RunLast),
+                    )
+                    .padding([4, 8])
+                    .style(crate::styles::nav_button),
+                    text(match self.left_browser.last_run() {
+                        Some(last) => format!("Re-run {}", last.path().display()),
+                        None => "Nothing has been run yet".to_string(),
+                    })
+                    .size(tiny),
+                    tooltip::Position::Top,
+                )
+                .style(crate::styles::subtle_tooltip),
                 text("|")
                     .size(tiny)
                     .color(iced::Color::from_rgb(0.4, 0.4, 0.45)),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -74,6 +74,11 @@ pub struct Preferences {
     pub default_song_duration: u32, // Default duration for songs without known length (in seconds)
     #[serde(default = "default_font_size")]
     pub font_size: u32, // Base font size for UI elements
+    /// Tab the user was on when they last closed the app. Restored at
+    /// startup. `#[serde(default)]` keeps older settings.json files (which
+    /// don't have this field) loading cleanly.
+    #[serde(default)]
+    pub last_active_tab: Option<crate::Tab>,
 }
 
 fn default_font_size() -> u32 {
@@ -105,6 +110,7 @@ impl Default for AppSettings {
                 show_hidden_files: false,
                 default_song_duration: 180, // 3 minutes
                 font_size: 12,
+                last_active_tab: None,
             },
         }
     }
@@ -132,5 +138,17 @@ impl AppSettings {
             log::info!("No settings file found, using defaults");
             Ok(Self::default())
         }
+    }
+
+    /// Persist the current settings to `settings.json`. Used after the user
+    /// changes a remembered preference (e.g. tab selection) — callers
+    /// generally ignore the result since a failed write is not worth
+    /// interrupting the UI for.
+    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let config_file = Self::config_path()?;
+        let json = serde_json::to_string_pretty(self)?;
+        fs::write(&config_file, json)?;
+        log::debug!("Settings saved to: {:?}", config_file);
+        Ok(())
     }
 }


### PR DESCRIPTION
- Window title now reads Ultimate64 Manager — <host> · <tab> and the app remembers which tab you closed in. 
- Two new device-control buttons in the file browser's F-key bar: ⏏ Eject A+B removes both mounted disks in one click (via the device's PUT /v1/drives/<drive>:remove endpoint), and  Run last re-fires the most recent PRG/CRT/SID/disk user sent.
