### PR TITLE
Defensive timeouts, Eject confirmation, click-outside dismiss, offlin…

### DIFF
--- a/src/config_presets.rs
+++ b/src/config_presets.rs
@@ -97,28 +97,47 @@ pub fn load_preset_from_file(path: &Path) -> Result<ConfigPreset, String> {
     Ok(preset)
 }
 
+/// 15s cap on preset file I/O — presets are tiny JSON; anything longer is
+/// a slow / unreachable storage mount and should fail loudly rather than
+/// pin the worker thread.
+const PRESET_IO_TIMEOUT_SECS: u64 = 15;
+
 /// Async wrapper for saving preset (for use with file dialog)
 pub async fn save_preset_async(
     preset: ConfigPreset,
     path: std::path::PathBuf,
 ) -> Result<String, String> {
-    tokio::task::spawn_blocking(move || {
-        save_preset_to_file(&preset, &path)?;
-        Ok(format!(
-            "Saved {} settings to {}",
-            preset.setting_count(),
-            path.file_name().and_then(|n| n.to_str()).unwrap_or("file")
-        ))
-    })
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(PRESET_IO_TIMEOUT_SECS),
+        tokio::task::spawn_blocking(move || {
+            save_preset_to_file(&preset, &path)?;
+            Ok(format!(
+                "Saved {} settings to {}",
+                preset.setting_count(),
+                path.file_name().and_then(|n| n.to_str()).unwrap_or("file")
+            ))
+        }),
+    )
     .await
-    .map_err(|e| format!("Task error: {}", e))?
+    {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(e)) => Err(format!("Task error: {}", e)),
+        Err(_) => Err("Preset save timed out — storage may be unreachable".into()),
+    }
 }
 
 /// Async wrapper for loading preset (for use with file dialog)
 pub async fn load_preset_async(path: std::path::PathBuf) -> Result<ConfigPreset, String> {
-    tokio::task::spawn_blocking(move || load_preset_from_file(&path))
-        .await
-        .map_err(|e| format!("Task error: {}", e))?
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(PRESET_IO_TIMEOUT_SECS),
+        tokio::task::spawn_blocking(move || load_preset_from_file(&path)),
+    )
+    .await
+    {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(e)) => Err(format!("Task error: {}", e)),
+        Err(_) => Err("Preset load timed out — storage may be unreachable".into()),
+    }
 }
 
 /// Create a preset from current category items

--- a/src/dir_preview.rs
+++ b/src/dir_preview.rs
@@ -330,11 +330,19 @@ pub fn render_disk_listing_image(disk_info: &DiskInfo) -> Vec<u8> {
     png_bytes
 }
 
-/// Async wrapper: render disk listing image on a blocking thread
+/// Async wrapper: render disk listing image on a blocking thread.
+/// 15s cap — rendering is a small in-memory PNG encode; anything longer
+/// means we're either OOMing or the encoder is wedged.
 pub async fn render_disk_listing_image_async(disk_info: DiskInfo) -> Vec<u8> {
-    tokio::task::spawn_blocking(move || render_disk_listing_image(&disk_info))
-        .await
-        .unwrap_or_default()
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        tokio::task::spawn_blocking(move || render_disk_listing_image(&disk_info)),
+    )
+    .await
+    {
+        Ok(Ok(bytes)) => bytes,
+        _ => Vec::new(),
+    }
 }
 
 /// Render a C64-style directory listing into a PNG image.
@@ -416,16 +424,32 @@ pub fn load_image_file(path: &Path) -> Result<ContentPreview, String> {
     })
 }
 
-/// Async wrapper for loading text file
+/// Async wrapper for loading text file. 15s cap — text reads are local
+/// disk I/O; a slow network mount or huge file shouldn't pin the worker.
 pub async fn load_text_file_async(path: PathBuf) -> Result<ContentPreview, String> {
-    tokio::task::spawn_blocking(move || load_text_file(&path))
-        .await
-        .map_err(|e| format!("Task error: {}", e))?
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        tokio::task::spawn_blocking(move || load_text_file(&path)),
+    )
+    .await
+    {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(e)) => Err(format!("Task error: {}", e)),
+        Err(_) => Err("Text preview timed out — file too large or slow storage".into()),
+    }
 }
 
-/// Async wrapper for loading image file
+/// Async wrapper for loading image file. 15s cap as above (image decoding
+/// can spin on corrupt PNGs / weird JPEGs).
 pub async fn load_image_file_async(path: PathBuf) -> Result<ContentPreview, String> {
-    tokio::task::spawn_blocking(move || load_image_file(&path))
-        .await
-        .map_err(|e| format!("Task error: {}", e))?
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        tokio::task::spawn_blocking(move || load_image_file(&path)),
+    )
+    .await
+    {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(e)) => Err(format!("Task error: {}", e)),
+        Err(_) => Err("Image preview timed out — file may be corrupt".into()),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,11 @@ use std::path::PathBuf;
 
 /// Background status poll cadence when the device is reachable.
 const STATUS_POLL_NORMAL_SECS: u64 = 60;
+/// Background reconnect cadence when the app has officially disconnected
+/// (consecutive failures exceeded [`MAX_TRANSIENT_STATUS_FAILURES`]) but the
+/// user still has a host configured. A successful poll flips back to
+/// "Connected" automatically — no user intervention needed.
+const STATUS_POLL_RECONNECT_SECS: u64 = 10;
 /// Faster poll cadence used during a transient outage window so a 2-3s
 /// reboot is recovered well before the user sees "Not connected".
 const STATUS_POLL_RETRY_SECS: u64 = 2;
@@ -326,8 +331,18 @@ pub enum Message {
     PoweroffMachine,
     MenuButton,
     MachineCommandCompleted(Result<String, String>),
-    /// Eject the disk image from both Drive A and Drive B.
+    /// Sink for events we explicitly want to absorb without doing anything
+    /// (e.g. clicks on a modal dialog's body so they don't bubble to the
+    /// backdrop's dismiss handler).
+    Nop,
+    /// Eject the disk image from both Drive A and Drive B. Shows a
+    /// confirmation dialog first — accidentally clearing a hand-set
+    /// mount has no undo, so we make the user confirm explicitly.
     EjectAllDrives,
+    /// User confirmed the Eject A+B prompt; actually fire the unmounts.
+    EjectAllDrivesConfirmed,
+    /// User dismissed the Eject A+B confirmation without confirming.
+    EjectCancel,
     EjectCompleted(Result<String, String>),
     /// Re-fire whatever PRG/CRT/SID/disk the local file browser most
     /// recently ran. No-op if no run has happened in this session.
@@ -552,6 +567,10 @@ pub struct Ultimate64Browser {
     drop_in_flight: bool,
     /// Handle for the in-flight drop task so the Cancel button can abort.
     drop_handle: Option<iced::task::Handle>,
+    /// True while the Eject A+B confirmation modal is showing. The actual
+    /// eject only fires after the user explicitly confirms — accidentally
+    /// clearing a mount has no undo.
+    pending_eject_confirm: bool,
     /// When true, the Help overlay (cheatsheet of every keybind) is rendered
     /// on top of whatever tab is active. Toggled by `?`.
     show_help: bool,
@@ -655,6 +674,7 @@ impl Ultimate64Browser {
             pending_drop: None,
             drop_in_flight: false,
             drop_handle: None,
+            pending_eject_confirm: false,
             show_help: false,
             main_window_id: Some(main_window_id),
             streaming_window_id: None,
@@ -2498,9 +2518,13 @@ impl Ultimate64Browser {
 
             Message::EscPressed => {
                 // Priority order: dismiss the most-modal thing first.
-                // Help overlay → drop dialog → fullscreen → pane quick-search.
+                // Help overlay → eject confirm → drop dialog → fullscreen → pane quick-search.
                 if self.show_help {
                     self.show_help = false;
+                    return Task::none();
+                }
+                if self.pending_eject_confirm {
+                    self.pending_eject_confirm = false;
                     return Task::none();
                 }
                 if self.pending_drop.is_some() {
@@ -2777,7 +2801,21 @@ impl Ultimate64Browser {
                 Task::none()
             }
 
+            Message::Nop => Task::none(),
+
             Message::EjectAllDrives => {
+                // Click on the toolbar button arms the confirmation modal —
+                // the actual ejection is gated on EjectAllDrivesConfirmed
+                // so an accidental click can't clear a hand-set mount.
+                self.pending_eject_confirm = true;
+                Task::none()
+            }
+            Message::EjectCancel => {
+                self.pending_eject_confirm = false;
+                Task::none()
+            }
+            Message::EjectAllDrivesConfirmed => {
+                self.pending_eject_confirm = false;
                 let host_url = format!("http://{}", self.settings.connection.host);
                 let password = self.settings.connection.password.clone();
                 // Fire both unmount calls in parallel; the device handles
@@ -3152,6 +3190,12 @@ impl Ultimate64Browser {
             return self.view_drop_dialog(dropped);
         }
 
+        // Eject A+B confirmation — guards against accidental clicks since
+        // there's no undo for clearing a mounted disk.
+        if self.pending_eject_confirm {
+            return self.view_eject_confirm_dialog();
+        }
+
         // Help overlay (`?` keypress) — global cheatsheet, takes
         // precedence over the normal tab view so the user can pop it
         // open from anywhere.
@@ -3398,19 +3442,28 @@ impl Ultimate64Browser {
         // Periodic connection check every 60 seconds
         // Suppressed while transferring or applying profiles to avoid
         // overwhelming the device's HTTP server
-        let status_check = if self.status.connected
-            && !self.remote_browser.is_transferring()
-            && !self.device_profile_manager.is_loading
+        let status_check = if self.remote_browser.is_transferring()
+            || self.device_profile_manager.is_loading
         {
-            // During an outage window (1..MAX failures) poll fast so a 2-3s
-            // reboot recovers before the user notices; otherwise idle at the
-            // normal background cadence.
+            // Suppress all polling while transferring or applying profiles
+            // to avoid overwhelming the device's HTTP server.
+            Subscription::none()
+        } else if self.status.connected {
+            // Connected — poll at the slow background cadence, but switch
+            // to a fast retry during a transient outage window so a 2-3s
+            // reboot recovers before the user notices.
             let interval_secs = if self.consecutive_status_failures > 0 {
                 STATUS_POLL_RETRY_SECS
             } else {
                 STATUS_POLL_NORMAL_SECS
             };
             iced::time::every(Duration::from_secs(interval_secs)).map(|_| Message::RefreshStatus)
+        } else if self.connection.is_some() {
+            // Officially disconnected but the user is still authenticated —
+            // keep tapping at the device so we silently reconnect when it
+            // comes back online (e.g. after a longer reboot).
+            iced::time::every(Duration::from_secs(STATUS_POLL_RECONNECT_SECS))
+                .map(|_| Message::RefreshStatus)
         } else {
             Subscription::none()
         };
@@ -3637,13 +3690,80 @@ impl Ultimate64Browser {
         })
         .width(Length::Fixed(420.0));
 
-        container(dialog)
+        // Click-outside-to-dismiss: the outer mouse_area covers the full
+        // backdrop and fires DropCancel; the inner mouse_area around the
+        // dialog absorbs clicks (with a Nop) so clicks ON the dialog itself
+        // — between buttons, on the border, etc. — don't bubble through.
+        // Button widgets capture their own clicks already, so this only
+        // affects "dead" space inside the dialog.
+        iced::widget::mouse_area(
+            container(
+                iced::widget::mouse_area(dialog).on_press(Message::Nop),
+            )
             .width(Length::Fill)
             .height(Length::Fill)
             .center_x(Length::Fill)
             .center_y(Length::Fill)
-            .padding(20)
-            .into()
+            .padding(20),
+        )
+        .on_press(Message::DropCancel)
+        .into()
+    }
+
+    /// Confirmation modal for the Eject A+B toolbar button. Mirrors the
+    /// drop-dialog overlay pattern so click-outside / Esc dismiss for free.
+    fn view_eject_confirm_dialog(&self) -> Element<'_, Message> {
+        let fs = crate::styles::FontSizes::from_base(self.settings.preferences.font_size);
+
+        let dialog = container(
+            column![
+                text("Eject both drives?").size(fs.large),
+                text("Drive A and Drive B will be cleared on the device. Any in-progress writes finish first; this cannot be undone.")
+                    .size(fs.small)
+                    .color(iced::Color::from_rgb(0.7, 0.7, 0.75)),
+                Space::new().height(12),
+                column![
+                    button(text("⏏ Yes, eject A+B").size(fs.normal))
+                        .on_press(Message::EjectAllDrivesConfirmed)
+                        .padding([6, 14])
+                        .width(Length::Fill)
+                        .style(iced::widget::button::danger),
+                    button(text("Cancel").size(fs.normal))
+                        .on_press(Message::EjectCancel)
+                        .padding([6, 14])
+                        .width(Length::Fill)
+                        .style(iced::widget::button::text),
+                ]
+                .spacing(8),
+            ]
+            .spacing(6)
+            .padding(20),
+        )
+        .style(|_theme| container::Style {
+            background: Some(iced::Background::Color(iced::Color::from_rgba(
+                0.18, 0.20, 0.28, 0.98,
+            ))),
+            border: iced::Border {
+                color: iced::Color::from_rgba(0.85, 0.4, 0.4, 0.7),
+                width: 1.0,
+                radius: 6.0.into(),
+            },
+            ..Default::default()
+        })
+        .width(Length::Fixed(380.0));
+
+        iced::widget::mouse_area(
+            container(
+                iced::widget::mouse_area(dialog).on_press(Message::Nop),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x(Length::Fill)
+            .center_y(Length::Fill)
+            .padding(20),
+        )
+        .on_press(Message::EjectCancel)
+        .into()
     }
 
     fn view_overwrite_dialog(&self, pending: &PendingCopy) -> Element<'_, Message> {

--- a/src/music_player.rs
+++ b/src/music_player.rs
@@ -569,9 +569,20 @@ impl MusicPlayer {
                 let root = self.browser_directory.clone();
                 Task::perform(
                     async move {
-                        tokio::task::spawn_blocking(move || search_files_recursive(&root, &query))
-                            .await
-                            .unwrap_or_default()
+                        // 60s cap — recursive music-library walks can be
+                        // huge on a properly-organised HVSC mirror but a
+                        // network mount shouldn't pin the runtime forever.
+                        match tokio::time::timeout(
+                            std::time::Duration::from_secs(60),
+                            tokio::task::spawn_blocking(move || {
+                                search_files_recursive(&root, &query)
+                            }),
+                        )
+                        .await
+                        {
+                            Ok(Ok(results)) => results,
+                            _ => Vec::new(),
+                        }
                     },
                     MusicPlayerMessage::BrowserSearchComplete,
                 )

--- a/src/pdf_preview.rs
+++ b/src/pdf_preview.rs
@@ -278,11 +278,27 @@ fn extract_pdf_text(data: &[u8], filename: String) -> Result<ContentPreview, Str
     })
 }
 
+/// Hard cap for PDF rendering — `pdf-extract` + `lopdf` are well-behaved on
+/// normal files but a corrupt or pathological PDF can spin for minutes. 30s
+/// covers any reasonable real document on slow disks; anything longer is
+/// almost certainly a bad file and we'd rather surface the failure.
+const PDF_TIMEOUT_SECS: u64 = 30;
+
 /// Async wrapper for loading PDF preview from path
 pub async fn load_pdf_preview_async(path: std::path::PathBuf) -> Result<ContentPreview, String> {
-    tokio::task::spawn_blocking(move || load_pdf_preview(&path))
-        .await
-        .map_err(|e| format!("Task error: {}", e))?
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(PDF_TIMEOUT_SECS),
+        tokio::task::spawn_blocking(move || load_pdf_preview(&path)),
+    )
+    .await
+    {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(e)) => Err(format!("Task error: {}", e)),
+        Err(_) => Err(format!(
+            "PDF preview timed out after {}s — file may be corrupt",
+            PDF_TIMEOUT_SECS
+        )),
+    }
 }
 
 /// Async wrapper for loading PDF preview from bytes
@@ -290,7 +306,17 @@ pub async fn load_pdf_preview_from_bytes_async(
     data: Vec<u8>,
     filename: String,
 ) -> Result<ContentPreview, String> {
-    tokio::task::spawn_blocking(move || load_pdf_preview_from_bytes(&data, filename))
-        .await
-        .map_err(|e| format!("Task error: {}", e))?
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(PDF_TIMEOUT_SECS),
+        tokio::task::spawn_blocking(move || load_pdf_preview_from_bytes(&data, filename)),
+    )
+    .await
+    {
+        Ok(Ok(inner)) => inner,
+        Ok(Err(e)) => Err(format!("Task error: {}", e)),
+        Err(_) => Err(format!(
+            "PDF preview timed out after {}s — file may be corrupt",
+            PDF_TIMEOUT_SECS
+        )),
+    }
 }


### PR DESCRIPTION
Adds a confirmation dialog for Eject A+B (no undo for an accidental click) and click-outside-to-dismiss for the drag-drop dialog, both with Esc support. 
The status poller now keeps tapping the device every 10s while officially disconnected so the app silently reconnects when the device comes back, instead of staying stuck on "Not connected" until the user clicks something. 
Wraps the remaining naked spawn_blocking sites (PDF preview, dir preview text/image/disk-listing, music-library search, config-preset save/load) with hard-cap tokio::time::timeout so slow or unreachable storage can't pin the worker thread.