### PR TITLE
feat: local rename, playlist queue/M3U, and Device tab controls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y libasound2-dev
     - name: Build

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://github.com/sandlbn/ultimate64-manager/releases
 - **Remote Directory Browser** – Browse the Ultimate filesystem without mounting disks
 - **Disk Image Viewer** – Display **D64/D71 directory contents** (C64-style listing)
 - **Disk Management** – Mount D64, D71, D81, G64, G71, G81 images to Drive A/B
-- **Run Programs** – Direct load and run for PRG, CRT, and SID files
+- **Run Programs** – Direct load and run for PRG, CRT, and SID files (PRG files also offer **Load** without running)
 - **Supported File Types** – D64, D71, D81, G64, G71, G81, PRG, P00, CRT, SID, MOD, XM, S3M, TAP, T64, REU, ROM, BIN, CFG, ZIP, and firmware updates (U2L, U2P, U2R, U64, UE2)
 - **Music Player** – Play SID and MOD files with playlist support
   - Shuffle and repeat modes
@@ -30,6 +30,8 @@ https://github.com/sandlbn/ultimate64-manager/releases
   - Song length database support (HVSC Songlengths.md5)
   - True pause/resume (freezes C64)
   - Configurable default song duration
+  - "Up Next" queue strip showing the next tracks in play order (honors shuffle)
+  - Import/export **M3U/PLS** playlists (relative paths resolved, duplicates skipped)
 - **Video Streaming** – Real-time VIC video with audio
   - Fullscreen mode (double-click or Opt+F / Alt+F)
   - Screenshot capture to Pictures folder
@@ -46,6 +48,11 @@ https://github.com/sandlbn/ultimate64-manager/releases
 - **Backup & Restore** – Full configuration backup and restore
 - **Machine Control** – Pause, Resume, Reset, Reboot, Power Off
 - **Remote Keyboard Input** – For BASIC only
+- **Device tab** – Low-level device capabilities in one place
+  - Live drive-type switching (1541 / 1571 / 1581), drive power on/off, and drive reset for Drive A/B
+  - Keyboard/text injection – feeds text into the KERNAL keyboard buffer (`$0277`) and presses RETURN. Works at the BASIC prompt and programs that read via the KERNAL (GETIN/CHRIN); **not** games that scan the keyboard matrix (`$DC00`) directly
+  - Debug register `$D7FF` read/write (U64 only)
+  - Debug bus-trace stream capture (U64 only) – records the cycle-accurate 6510/VIC/1541 stream to a raw `.bin` for the documented GtkWave/VCD converter
 - **Assembly64 Browser** – Search the Assembly64 API (aggregates CSDB, HVSC, c64.org, OneLoad64, Gamebase64 and more)
   - Filter by type, source, rating, recency, and sort order — no AQL knowledge required
   - Save named searches and star favorites for one-click recall

--- a/src/api.rs
+++ b/src/api.rs
@@ -578,3 +578,203 @@ pub async fn upload_runner_async(
     }
     Ok(())
 }
+
+// ─────────────────────────────────────────────────────────────────
+//  Drive control (mode / power / reset). `host` includes the scheme,
+//  e.g. "http://10.0.0.139"; `drive` is "a" or "b".
+// ─────────────────────────────────────────────────────────────────
+
+/// Switch a drive's emulated hardware type live.
+/// `mode` is one of "1541", "1571", "1581".
+/// PUT /v1/drives/<drive>:set_mode?mode=<mode>
+pub async fn set_drive_mode_async(
+    host: &str,
+    drive: &str,
+    mode: &str,
+    password: Option<&str>,
+) -> Result<String, String> {
+    let url = format!("{}/v1/drives/{}:set_mode", host, drive);
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let req = crate::net_utils::with_password(client.put(&url).query(&[("mode", mode)]), password);
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("Drive {} set mode: {}", drive.to_uppercase(), e))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "Drive {} set mode: HTTP {}",
+            drive.to_uppercase(),
+            resp.status()
+        ));
+    }
+    Ok(format!("Drive {} → {}", drive.to_uppercase(), mode))
+}
+
+/// Power a drive on or off.
+/// PUT /v1/drives/<drive>:on | :off
+pub async fn drive_power_async(
+    host: &str,
+    drive: &str,
+    on: bool,
+    password: Option<&str>,
+) -> Result<String, String> {
+    let action = if on { "on" } else { "off" };
+    let url = format!("{}/v1/drives/{}:{}", host, drive, action);
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let req = crate::net_utils::with_password(client.put(&url), password);
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("Drive {} power {}: {}", drive.to_uppercase(), action, e))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "Drive {} power {}: HTTP {}",
+            drive.to_uppercase(),
+            action,
+            resp.status()
+        ));
+    }
+    Ok(format!("Drive {} powered {}", drive.to_uppercase(), action))
+}
+
+/// Reset a drive.
+/// PUT /v1/drives/<drive>:reset
+pub async fn drive_reset_async(
+    host: &str,
+    drive: &str,
+    password: Option<&str>,
+) -> Result<String, String> {
+    let url = format!("{}/v1/drives/{}:reset", host, drive);
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let req = crate::net_utils::with_password(client.put(&url), password);
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("Drive {} reset: {}", drive.to_uppercase(), e))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "Drive {} reset: HTTP {}",
+            drive.to_uppercase(),
+            resp.status()
+        ));
+    }
+    Ok(format!("Drive {} reset", drive.to_uppercase()))
+}
+
+/// Load a PRG into C64 memory *without* running it.
+/// PUT /v1/runners:load_prg?file=<path>
+pub async fn load_prg_async(
+    host: &str,
+    file_path: &str,
+    password: Option<&str>,
+) -> Result<String, String> {
+    let url = format!("{}/v1/runners:load_prg", host);
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let req =
+        crate::net_utils::with_password(client.put(&url).query(&[("file", file_path)]), password);
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("load_prg failed: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("load_prg HTTP {}", resp.status()));
+    }
+    let filename = file_path.rsplit('/').next().unwrap_or(file_path);
+    Ok(format!("Loaded: {}", filename))
+}
+
+/// Read the debug register ($D7FF, U64 only).
+/// GET /v1/machine:debugreg  → body is the value (hex or decimal text).
+pub async fn read_debugreg_async(host: &str, password: Option<&str>) -> Result<u8, String> {
+    let url = format!("{}/v1/machine:debugreg", host);
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let req = crate::net_utils::with_password(client.get(&url), password);
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("debugreg read: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("debugreg read HTTP {}", resp.status()));
+    }
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("debugreg read body: {}", e))?;
+    parse_debugreg_value(&body)
+        .ok_or_else(|| format!("debugreg: could not parse value from '{}'", body.trim()))
+}
+
+/// Write the debug register ($D7FF, U64 only).
+/// PUT /v1/machine:debugreg?value=<hex>
+pub async fn write_debugreg_async(
+    host: &str,
+    value: u8,
+    password: Option<&str>,
+) -> Result<String, String> {
+    let url = format!("{}/v1/machine:debugreg", host);
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let value_str = format!("{:02x}", value);
+    let req = crate::net_utils::with_password(
+        client.put(&url).query(&[("value", value_str.as_str())]),
+        password,
+    );
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("debugreg write: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!("debugreg write HTTP {}", resp.status()));
+    }
+    Ok(format!("Debug register = ${:02X}", value))
+}
+
+/// Parse a debug-register value returned by the device. Accepts a bare
+/// number, an optional `0x`/`$` hex prefix, or a JSON-ish `{"value": N}`
+/// fragment — returns the low byte.
+fn parse_debugreg_value(body: &str) -> Option<u8> {
+    let mut s = body.trim();
+    // Pull a value out of a trivial `"value": 123` shape if present.
+    if let Some(pos) = s.find(':') {
+        if s.contains('{') || s.contains("value") {
+            s = s[pos + 1..]
+                .trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != 'x' && c != '$');
+        }
+    }
+    let s = s.trim();
+    let parsed = if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("$")) {
+        u32::from_str_radix(hex.trim(), 16).ok()
+    } else {
+        // Try decimal first, then fall back to hex for bare hex like "ff".
+        s.parse::<u32>()
+            .ok()
+            .or_else(|| u32::from_str_radix(s, 16).ok())
+    };
+    parsed.map(|v| (v & 0xff) as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_debugreg_decimal() {
+        assert_eq!(parse_debugreg_value("255"), Some(255));
+        assert_eq!(parse_debugreg_value(" 16 "), Some(16));
+    }
+
+    #[test]
+    fn parse_debugreg_hex_prefixes() {
+        assert_eq!(parse_debugreg_value("0xff"), Some(0xff));
+        assert_eq!(parse_debugreg_value("$1A"), Some(0x1a));
+    }
+
+    #[test]
+    fn parse_debugreg_json_fragment() {
+        assert_eq!(parse_debugreg_value("{\"value\": 42}"), Some(42));
+    }
+
+    #[test]
+    fn parse_debugreg_rejects_garbage() {
+        assert_eq!(parse_debugreg_value("hello"), None);
+    }
+}

--- a/src/debug_stream.rs
+++ b/src/debug_stream.rs
@@ -1,0 +1,239 @@
+// Debug bus-trace stream capture.
+//
+// The Ultimate64 can emit a cycle-accurate 6510/VIC/1541 bus trace over UDP
+// (`PUT /v1/streams/debug:start`, firmware ≥ 3.7). The datagram sample layout
+// is generated FPGA-side and is not part of the public REST/socket docs, so we
+// deliberately do NOT try to decode it into VCD here — inventing a layout would
+// produce silently-wrong waveforms. Instead we capture the raw datagram payload
+// stream to a file, which the documented external converter turns into a
+// GtkWave `.vcd`.
+//
+// Mechanically this mirrors `streaming.rs`: bind the UDP socket first, send the
+// start command over the existing stream-control layer, then read datagrams on
+// a background thread into a shared buffer with a stop flag and counters. The UI
+// polls the counters on a timer.
+
+use std::net::UdpSocket;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use crate::net_utils::get_local_ip;
+use crate::settings::StreamControlMethod;
+use crate::stream_control::{send_stop_command, send_stream_command};
+
+/// Binary stream command id for the debug stream (see stream_control.rs).
+const STREAM_CMD_DEBUG: u8 = 0x22;
+/// Default UDP port for the debug stream (video=11000, audio=11001, debug=11002).
+pub const DEFAULT_DEBUG_PORT: u16 = 11002;
+
+/// Raw debug-stream capture engine. One instance lives in the app; `start`
+/// spins up a reader thread and `stop` tears it down.
+pub struct DebugStreamCapture {
+    pub active: bool,
+    pub listen_port: u16,
+    /// Device host (bare IP/hostname, no scheme) and API password for the
+    /// port-64 / REST stream-control command.
+    ultimate_host: Option<String>,
+    api_password: Option<String>,
+    stream_control_method: StreamControlMethod,
+
+    stop_signal: Arc<AtomicBool>,
+    capture: Arc<Mutex<Vec<u8>>>,
+    packets: Arc<AtomicU64>,
+    bytes: Arc<AtomicU64>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Default for DebugStreamCapture {
+    fn default() -> Self {
+        Self {
+            active: false,
+            listen_port: DEFAULT_DEBUG_PORT,
+            ultimate_host: None,
+            api_password: None,
+            stream_control_method: StreamControlMethod::default(),
+            stop_signal: Arc::new(AtomicBool::new(false)),
+            capture: Arc::new(Mutex::new(Vec::new())),
+            packets: Arc::new(AtomicU64::new(0)),
+            bytes: Arc::new(AtomicU64::new(0)),
+            handle: None,
+        }
+    }
+}
+
+impl DebugStreamCapture {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update the device connection parameters used for the start/stop command.
+    /// `host` may include a scheme — it is stripped to a bare host.
+    pub fn set_host(
+        &mut self,
+        host: Option<String>,
+        password: Option<String>,
+        method: StreamControlMethod,
+    ) {
+        self.ultimate_host = host.map(|h| {
+            h.trim_start_matches("http://")
+                .trim_start_matches("https://")
+                .to_string()
+        });
+        self.api_password = password;
+        self.stream_control_method = method;
+    }
+
+    pub fn packets(&self) -> u64 {
+        self.packets.load(Ordering::Relaxed)
+    }
+
+    pub fn bytes(&self) -> u64 {
+        self.bytes.load(Ordering::Relaxed)
+    }
+
+    /// Number of bytes currently held in the capture buffer.
+    pub fn captured_len(&self) -> usize {
+        self.capture.lock().map(|c| c.len()).unwrap_or(0)
+    }
+
+    /// Start capturing. Returns Err with a message if the socket can't bind or
+    /// no device host is configured.
+    pub fn start(&mut self) -> Result<(), String> {
+        if self.active {
+            return Ok(());
+        }
+        let Some(ultimate_ip) = self.ultimate_host.clone() else {
+            return Err("Not connected".to_string());
+        };
+        let port = self.listen_port;
+
+        // Bind the socket BEFORE sending the start command (matches streaming.rs).
+        let socket = UdpSocket::bind(format!("0.0.0.0:{}", port))
+            .map_err(|e| format!("Failed to bind UDP :{} — {}", port, e))?;
+        socket
+            .set_nonblocking(true)
+            .map_err(|e| format!("Socket config failed: {}", e))?;
+
+        // Fresh capture + counters.
+        self.stop_signal.store(false, Ordering::Relaxed);
+        self.packets.store(0, Ordering::Relaxed);
+        self.bytes.store(0, Ordering::Relaxed);
+        if let Ok(mut c) = self.capture.lock() {
+            c.clear();
+        }
+
+        // Send the debug-stream start command to the device.
+        let my_ip = get_local_ip().ok_or("Could not detect local IP address")?;
+        // Ensure any prior debug stream is stopped first.
+        let _ = send_stop_command(
+            &ultimate_ip,
+            STREAM_CMD_DEBUG,
+            self.api_password.as_deref(),
+            self.stream_control_method,
+        );
+        send_stream_command(
+            &ultimate_ip,
+            &my_ip,
+            port,
+            STREAM_CMD_DEBUG,
+            self.api_password.as_deref(),
+            self.stream_control_method,
+        )
+        .map_err(|e| format!("Failed to start debug stream: {}", e))?;
+
+        // Reader thread: append raw datagram payloads to the capture buffer.
+        let stop_signal = self.stop_signal.clone();
+        let capture = self.capture.clone();
+        let packets = self.packets.clone();
+        let bytes = self.bytes.clone();
+        let handle = thread::spawn(move || {
+            // Debug datagrams are ~1444 bytes; use a generous buffer.
+            let mut recv_buf = [0u8; 2048];
+            loop {
+                if stop_signal.load(Ordering::Relaxed) {
+                    break;
+                }
+                match socket.recv_from(&mut recv_buf) {
+                    Ok((size, _addr)) => {
+                        if size == 0 {
+                            continue;
+                        }
+                        packets.fetch_add(1, Ordering::Relaxed);
+                        bytes.fetch_add(size as u64, Ordering::Relaxed);
+                        if let Ok(mut c) = capture.lock() {
+                            // Cap the in-memory capture at 256 MiB as a safety
+                            // valve so a forgotten capture can't exhaust RAM.
+                            const CAP: usize = 256 * 1024 * 1024;
+                            if c.len() + size <= CAP {
+                                c.extend_from_slice(&recv_buf[..size]);
+                            }
+                        }
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(std::time::Duration::from_millis(2));
+                    }
+                    Err(e) => {
+                        log::error!("Debug stream recv error: {}", e);
+                        break;
+                    }
+                }
+            }
+            log::info!("Debug stream reader thread stopped");
+        });
+
+        self.handle = Some(handle);
+        self.active = true;
+        log::info!("Debug stream capture started on :{}", port);
+        Ok(())
+    }
+
+    /// Stop capturing and send the stop command to the device. The captured
+    /// bytes remain available via [`take_capture`] until the next `start`.
+    pub fn stop(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.stop_signal.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+        if let Some(ultimate_ip) = &self.ultimate_host {
+            let _ = send_stop_command(
+                ultimate_ip,
+                STREAM_CMD_DEBUG,
+                self.api_password.as_deref(),
+                self.stream_control_method,
+            );
+        }
+        self.active = false;
+        log::info!(
+            "Debug stream capture stopped ({} packets, {} bytes)",
+            self.packets(),
+            self.bytes()
+        );
+    }
+
+    /// Snapshot the current capture buffer (does not clear it).
+    pub fn snapshot(&self) -> Vec<u8> {
+        self.capture.lock().map(|c| c.clone()).unwrap_or_default()
+    }
+}
+
+/// Save a raw debug-stream capture to a file the user picks.
+pub async fn save_capture_async(data: Vec<u8>) -> Result<String, String> {
+    if data.is_empty() {
+        return Err("Nothing captured yet".to_string());
+    }
+    let handle = rfd::AsyncFileDialog::new()
+        .add_filter("Debug capture", &["bin", "u64dbg"])
+        .set_file_name("debug-capture.bin")
+        .save_file()
+        .await
+        .ok_or("Save cancelled")?;
+    let path = handle.path().to_path_buf();
+    tokio::fs::write(&path, &data)
+        .await
+        .map_err(|e| format!("Write error: {}", e))?;
+    Ok(path.to_string_lossy().to_string())
+}

--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -84,6 +84,15 @@ pub enum FileBrowserMessage {
     CreateDirNameChanged(String),
     CreateDirConfirm,
     CreateDirCancel,
+    // Local rename (F2 on the local pane)
+    /// Open the rename dialog for a local path (name pre-filled)
+    RenameFile(PathBuf),
+    /// User is typing the new name
+    RenameInputChanged(String),
+    /// Execute the rename via std::fs::rename
+    RenameConfirm,
+    /// Dismiss the rename dialog
+    RenameCancel,
     // Favorites
     /// Toggle the *current* directory in/out of favorites (toolbar star).
     ToggleCurrentFavorite,
@@ -206,6 +215,14 @@ impl LastRun {
     }
 }
 
+/// State for the local file-rename dialog (F2 on the local pane).
+struct LocalRenamePending {
+    /// Full path of the file/folder being renamed
+    original_path: PathBuf,
+    /// Current value of the name text input
+    new_name: String,
+}
+
 pub struct FileBrowser {
     current_directory: PathBuf,
     files: Vec<FileEntry>,
@@ -240,6 +257,8 @@ pub struct FileBrowser {
     // Create directory dialog
     show_create_dir: bool,
     create_dir_name: String,
+    // Local rename dialog: Some(...) while the user is renaming a local file
+    rename_pending: Option<LocalRenamePending>,
     // Create disk image dialog
     show_create_disk: bool,
     create_disk_name: String,
@@ -302,6 +321,7 @@ impl FileBrowser {
             delete_pending: None,
             show_create_dir: false,
             create_dir_name: String::new(),
+            rename_pending: None,
             show_create_disk: false,
             create_disk_name: "NEWDISK".to_string(),
             create_disk_id: "01 2A".to_string(),
@@ -1074,6 +1094,77 @@ impl FileBrowser {
                 Task::none()
             }
 
+            // ── Local rename (F2) ────────────────────────────────────────
+            FileBrowserMessage::RenameFile(path) => {
+                let current_name = path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                self.rename_pending = Some(LocalRenamePending {
+                    original_path: path,
+                    new_name: current_name,
+                });
+                Task::none()
+            }
+            FileBrowserMessage::RenameInputChanged(value) => {
+                if let Some(ref mut rp) = self.rename_pending {
+                    rp.new_name = value;
+                }
+                Task::none()
+            }
+            FileBrowserMessage::RenameConfirm => {
+                let Some(rp) = self.rename_pending.take() else {
+                    return Task::none();
+                };
+                let new_name = rp.new_name.trim();
+                // Validate: non-empty, changed, and a bare filename (no separators)
+                if new_name.is_empty() {
+                    self.status_message = Some("Rename: name cannot be empty".to_string());
+                    return Task::none();
+                }
+                if new_name.contains('/') || new_name.contains('\\') {
+                    self.status_message =
+                        Some("Rename: name cannot contain path separators".to_string());
+                    return Task::none();
+                }
+                let old_name = rp
+                    .original_path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("");
+                if new_name == old_name {
+                    // No change — silently close.
+                    return Task::none();
+                }
+                let parent = rp
+                    .original_path
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| self.current_directory.clone());
+                let new_path = parent.join(new_name);
+                if new_path.exists() {
+                    self.status_message = Some(format!("Rename: \"{}\" already exists", new_name));
+                    return Task::none();
+                }
+                match std::fs::rename(&rp.original_path, &new_path) {
+                    Ok(_) => {
+                        self.status_message = Some(format!("Renamed to: {}", new_name));
+                        // Keep the renamed entry selected after refresh.
+                        self.selected_file = Some(new_path);
+                        self.load_directory(&self.current_directory.clone());
+                    }
+                    Err(e) => {
+                        self.status_message = Some(format!("Rename error: {}", e));
+                    }
+                }
+                Task::none()
+            }
+            FileBrowserMessage::RenameCancel => {
+                self.rename_pending = None;
+                Task::none()
+            }
+
             // ── Favorites ────────────────────────────────────────────────
             FileBrowserMessage::ToggleCurrentFavorite => {
                 let current = self.current_directory.clone();
@@ -1756,6 +1847,60 @@ impl FileBrowser {
                             .style(button::secondary),
                         button(text("Cancel").size(fs.small))
                             .on_press(FileBrowserMessage::DeleteCancelled)
+                            .padding([5, 15])
+                            .style(button::secondary),
+                    ]
+                    .spacing(10),
+                ]
+                .spacing(10)
+                .padding(15),
+            )
+            .style(crate::styles::subtle_tooltip)
+            .width(Length::Fill);
+
+            column![
+                self.build_nav_row(font_size),
+                self.build_quick_nav_row(font_size),
+                dialog,
+                self.build_status_bar(font_size),
+            ]
+            .spacing(2)
+            .padding(5)
+            .into()
+        } else if let Some(ref rp) = self.rename_pending {
+            // Local rename dialog
+            let original_name = rp
+                .original_path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("");
+            let dialog = container(
+                column![
+                    text("Rename").size(fs.normal),
+                    row![
+                        text("From:").size(fs.small),
+                        text(original_name).size(fs.small),
+                    ]
+                    .spacing(8)
+                    .align_y(iced::Alignment::Center),
+                    row![
+                        text("To:").size(fs.small),
+                        iced::widget::text_input("new name...", &rp.new_name)
+                            .on_input(FileBrowserMessage::RenameInputChanged)
+                            .on_submit(FileBrowserMessage::RenameConfirm)
+                            .size(fs.small as f32)
+                            .padding(4)
+                            .width(Length::Fixed(240.0)),
+                    ]
+                    .spacing(8)
+                    .align_y(iced::Alignment::Center),
+                    row![
+                        button(text("Rename").size(fs.small))
+                            .on_press(FileBrowserMessage::RenameConfirm)
+                            .padding([5, 15])
+                            .style(button::secondary),
+                        button(text("Cancel").size(fs.small))
+                            .on_press(FileBrowserMessage::RenameCancel)
                             .padding([5, 15])
                             .style(button::secondary),
                     ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,7 @@ mod config_api;
 mod config_editor;
 mod config_presets;
 mod csdb_screenshots;
+mod debug_stream;
 mod device_profile;
 mod dir_preview;
 mod discovery;
@@ -331,6 +332,36 @@ pub enum Message {
     PoweroffMachine,
     MenuButton,
     MachineCommandCompleted(Result<String, String>),
+    // ── DEVICE tab: drive control / keyboard / debug register ────────
+    /// Switch a drive's emulated type. (drive "a"|"b", mode "1541"|"1571"|"1581")
+    DeviceSetDriveMode(String, String),
+    /// Power a drive on (true) or off (false). (drive, on)
+    DeviceDrivePower(String, bool),
+    /// Reset a drive. (drive)
+    DeviceDriveReset(String),
+    /// Text field for keyboard injection.
+    DeviceKeyboardInputChanged(String),
+    /// Send the buffered text into the running C64 keyboard buffer.
+    DeviceSendKeys,
+    /// Debug-register write-value text field (hex).
+    DeviceDebugRegInputChanged(String),
+    /// Read the debug register ($D7FF).
+    DeviceReadDebugReg,
+    /// Result of a debug-register read.
+    DeviceDebugRegRead(Result<u8, String>),
+    /// Write the debug register with the buffered value.
+    DeviceWriteDebugReg,
+    // ── DEVICE tab: debug bus-trace stream capture ───────────────────
+    /// Start capturing the debug bus-trace stream.
+    DeviceDebugStreamStart,
+    /// Stop the debug-stream capture.
+    DeviceDebugStreamStop,
+    /// Timer tick to refresh capture counters while active.
+    DeviceDebugStreamTick,
+    /// Save the captured debug stream to a file.
+    DeviceDebugStreamSave,
+    /// Result of a debug-stream save.
+    DeviceDebugStreamSaved(Result<String, String>),
     /// Sink for events we explicitly want to absorb without doing anything
     /// (e.g. clicks on a modal dialog's body so they don't bubble to the
     /// backdrop's dismiss handler).
@@ -494,6 +525,7 @@ pub enum Tab {
     Profiles,
     Assembly64,
     BasicEditor,
+    Device,
     Settings,
 }
 
@@ -509,6 +541,7 @@ impl std::fmt::Display for Tab {
             Tab::Profiles => write!(f, "Profiles"),
             Tab::Assembly64 => write!(f, "Assembly64"),
             Tab::BasicEditor => write!(f, "BASIC"),
+            Tab::Device => write!(f, "Device"),
             Tab::Settings => write!(f, "Settings"),
         }
     }
@@ -551,6 +584,14 @@ pub struct Ultimate64Browser {
     connection: Option<Arc<TokioMutex<Rest>>>,
     host_url: Option<String>, // Store host URL for direct HTTP requests
     status: StatusInfo,
+    /// DEVICE tab: buffered text to inject into the running C64 keyboard.
+    device_keyboard_input: String,
+    /// DEVICE tab: input for the debug-register write value (hex).
+    device_debugreg_input: String,
+    /// DEVICE tab: last value read from the debug register ($D7FF).
+    device_debugreg_value: Option<u8>,
+    /// DEVICE tab: raw debug bus-trace stream capture engine.
+    debug_stream: debug_stream::DebugStreamCapture,
     /// Count of back-to-back failed status polls. We only flip the UI to
     /// "Not connected" once it crosses [`MAX_TRANSIENT_STATUS_FAILURES`],
     /// so a 2-3 second reboot blip doesn't show as a disconnect.
@@ -683,6 +724,10 @@ impl Ultimate64Browser {
             font_size_input: settings.preferences.font_size.to_string(),
             settings: settings.clone(),
             host_url: None,
+            device_keyboard_input: String::new(),
+            device_debugreg_input: String::new(),
+            device_debugreg_value: None,
+            debug_stream: debug_stream::DebugStreamCapture::new(),
             template_manager: TemplateManager::new(),
             selected_template: None,
             connection: None,
@@ -1355,9 +1400,19 @@ impl Ultimate64Browser {
             Message::FnRename => {
                 match self.active_pane {
                     Pane::Left => {
-                        // Local rename not supported via function bar yet
+                        if let Some(path) = self.left_browser.get_selected_file().cloned() {
+                            return self
+                                .left_browser
+                                .update(
+                                    FileBrowserMessage::RenameFile(path),
+                                    self.connection.clone(),
+                                    Some(self.settings.connection.host.clone()),
+                                    self.settings.connection.password.clone(),
+                                )
+                                .map(Message::LeftBrowser);
+                        }
                         self.user_message = Some(UserMessage::Info(
-                            "Select a file and use your OS to rename local files".to_string(),
+                            "Click a file first, then press F2 to rename".to_string(),
                         ));
                         Task::none()
                     }
@@ -3125,6 +3180,171 @@ impl Ultimate64Browser {
                 }
                 Task::none()
             }
+
+            // ── DEVICE tab handlers ──────────────────────────────────────
+            Message::DeviceSetDriveMode(drive, mode) => {
+                let Some(host) = self.host_url.clone() else {
+                    self.user_message = Some(UserMessage::Error("Not connected".to_string()));
+                    return Task::none();
+                };
+                let password = self.settings.connection.password.clone();
+                Task::perform(
+                    async move {
+                        api::set_drive_mode_async(&host, &drive, &mode, password.as_deref()).await
+                    },
+                    Message::MachineCommandCompleted,
+                )
+            }
+            Message::DeviceDrivePower(drive, on) => {
+                let Some(host) = self.host_url.clone() else {
+                    self.user_message = Some(UserMessage::Error("Not connected".to_string()));
+                    return Task::none();
+                };
+                let password = self.settings.connection.password.clone();
+                Task::perform(
+                    async move { api::drive_power_async(&host, &drive, on, password.as_deref()).await },
+                    Message::MachineCommandCompleted,
+                )
+            }
+            Message::DeviceDriveReset(drive) => {
+                let Some(host) = self.host_url.clone() else {
+                    self.user_message = Some(UserMessage::Error("Not connected".to_string()));
+                    return Task::none();
+                };
+                let password = self.settings.connection.password.clone();
+                Task::perform(
+                    async move { api::drive_reset_async(&host, &drive, password.as_deref()).await },
+                    Message::MachineCommandCompleted,
+                )
+            }
+            Message::DeviceKeyboardInputChanged(value) => {
+                self.device_keyboard_input = value;
+                Task::none()
+            }
+            Message::DeviceSendKeys => {
+                let Some(host) = self.host_url.clone() else {
+                    self.user_message = Some(UserMessage::Error("Not connected".to_string()));
+                    return Task::none();
+                };
+                if self.device_keyboard_input.is_empty() {
+                    return Task::none();
+                }
+                let password = self.settings.connection.password.clone();
+                // Append RETURN so a typed command actually executes. This writes
+                // PETSCII into the KERNAL keyboard buffer ($0277) — only code that
+                // reads via the KERNAL (BASIC prompt, GETIN) sees it; programs
+                // scanning the CIA keyboard matrix directly do not.
+                let text = format!("{}\n", self.device_keyboard_input);
+                Task::perform(
+                    async move {
+                        api::type_text_async(&host, &text, password.as_deref())
+                            .await
+                            .map(|_| "Sent keystrokes".to_string())
+                    },
+                    Message::MachineCommandCompleted,
+                )
+            }
+            Message::DeviceDebugRegInputChanged(value) => {
+                self.device_debugreg_input = value;
+                Task::none()
+            }
+            Message::DeviceReadDebugReg => {
+                let Some(host) = self.host_url.clone() else {
+                    self.user_message = Some(UserMessage::Error("Not connected".to_string()));
+                    return Task::none();
+                };
+                let password = self.settings.connection.password.clone();
+                Task::perform(
+                    async move { api::read_debugreg_async(&host, password.as_deref()).await },
+                    Message::DeviceDebugRegRead,
+                )
+            }
+            Message::DeviceDebugRegRead(result) => {
+                match result {
+                    Ok(v) => {
+                        self.device_debugreg_value = Some(v);
+                        self.user_message =
+                            Some(UserMessage::Info(format!("Debug register = ${:02X}", v)));
+                    }
+                    Err(e) => {
+                        self.user_message = Some(UserMessage::Error(e));
+                    }
+                }
+                Task::none()
+            }
+            Message::DeviceWriteDebugReg => {
+                let Some(host) = self.host_url.clone() else {
+                    self.user_message = Some(UserMessage::Error("Not connected".to_string()));
+                    return Task::none();
+                };
+                // Accept hex with optional 0x/$ prefix.
+                let raw = self.device_debugreg_input.trim();
+                let raw = raw
+                    .strip_prefix("0x")
+                    .or_else(|| raw.strip_prefix('$'))
+                    .unwrap_or(raw);
+                let Ok(value) = u8::from_str_radix(raw, 16) else {
+                    self.user_message = Some(UserMessage::Error(
+                        "Debug register: enter a hex byte (00–FF)".to_string(),
+                    ));
+                    return Task::none();
+                };
+                let password = self.settings.connection.password.clone();
+                Task::perform(
+                    async move { api::write_debugreg_async(&host, value, password.as_deref()).await },
+                    Message::MachineCommandCompleted,
+                )
+            }
+            Message::DeviceDebugStreamStart => {
+                self.debug_stream.set_host(
+                    self.host_url.clone(),
+                    self.settings.connection.password.clone(),
+                    self.settings.connection.stream_control_method,
+                );
+                match self.debug_stream.start() {
+                    Ok(()) => {
+                        self.user_message = Some(UserMessage::Info(
+                            "Debug stream capture started".to_string(),
+                        ));
+                    }
+                    Err(e) => {
+                        self.user_message =
+                            Some(UserMessage::Error(format!("Debug stream: {}", e)));
+                    }
+                }
+                Task::none()
+            }
+            Message::DeviceDebugStreamStop => {
+                self.debug_stream.stop();
+                self.user_message = Some(UserMessage::Info(format!(
+                    "Debug stream stopped — {} packets captured",
+                    self.debug_stream.packets()
+                )));
+                Task::none()
+            }
+            Message::DeviceDebugStreamTick => {
+                // Counters live in shared atomics; a redraw is enough.
+                Task::none()
+            }
+            Message::DeviceDebugStreamSave => {
+                let data = self.debug_stream.snapshot();
+                Task::perform(
+                    debug_stream::save_capture_async(data),
+                    Message::DeviceDebugStreamSaved,
+                )
+            }
+            Message::DeviceDebugStreamSaved(result) => {
+                match result {
+                    Ok(path) => {
+                        self.user_message =
+                            Some(UserMessage::Info(format!("Capture saved: {}", path)));
+                    }
+                    Err(e) => {
+                        self.user_message = Some(UserMessage::Error(e));
+                    }
+                }
+                Task::none()
+            }
             Message::DefaultSongDurationChanged(value) => {
                 if let Ok(duration) = value.parse::<u32>() {
                     if duration > 0 && duration <= 3600 {
@@ -3304,6 +3524,7 @@ impl Ultimate64Browser {
                 // self.tab_button("PROFILES", Tab::Profiles),
                 self.tab_button("ASSEMBLY64", Tab::Assembly64),
                 self.tab_button("BASIC", Tab::BasicEditor),
+                self.tab_button("DEVICE", Tab::Device),
                 self.tab_button("SETTINGS", Tab::Settings),
             ]
             .spacing(2),
@@ -3368,6 +3589,7 @@ impl Ultimate64Browser {
                 .basic_editor
                 .view(self.settings.preferences.font_size, self.status.connected)
                 .map(Message::BasicEditor),
+            Tab::Device => self.view_device(),
             Tab::Settings => self.view_settings(),
         })
         .padding(10)
@@ -3614,6 +3836,13 @@ impl Ultimate64Browser {
             Subscription::none()
         };
 
+        // Refresh the debug-stream capture counters while active.
+        let debug_stream_tick = if self.debug_stream.active {
+            iced::time::every(Duration::from_millis(500)).map(|_| Message::DeviceDebugStreamTick)
+        } else {
+            Subscription::none()
+        };
+
         Subscription::batch([
             self.video_streaming.subscription().map(Message::Streaming),
             self.music_player.subscription().map(Message::MusicPlayer),
@@ -3627,6 +3856,7 @@ impl Ultimate64Browser {
             status_check,
             copy_progress_tick,
             toast_tick,
+            debug_stream_tick,
         ])
     }
 
@@ -4659,6 +4889,206 @@ impl Ultimate64Browser {
         )
         .height(Length::Fill)
         .into()
+    }
+
+    /// Debug bus-trace stream capture controls (part of the DEVICE tab).
+    fn view_debug_stream_section(&self) -> Element<'_, Message> {
+        let fs = crate::styles::FontSizes::from_base(self.settings.preferences.font_size);
+        let connected = self.status.connected;
+        let active = self.debug_stream.active;
+
+        let captured_kib = self.debug_stream.captured_len() as f64 / 1024.0;
+        let stats = text(format!(
+            "{} · {} packets · {:.1} KiB captured",
+            if active { "CAPTURING" } else { "idle" },
+            self.debug_stream.packets(),
+            captured_kib,
+        ))
+        .size(fs.small)
+        .color(iced::Color::from_rgb(0.6, 0.7, 0.8));
+
+        let start_stop = if active {
+            button(text("Stop").size(fs.small))
+                .on_press(Message::DeviceDebugStreamStop)
+                .padding([4, 10])
+                .style(crate::styles::action_button)
+        } else {
+            button(text("Start Capture").size(fs.small))
+                .on_press_maybe(connected.then_some(Message::DeviceDebugStreamStart))
+                .padding([4, 10])
+                .style(crate::styles::action_button)
+        };
+
+        let save_btn = button(text("Save Capture…").size(fs.small))
+            .on_press_maybe(
+                (!active && self.debug_stream.captured_len() > 0)
+                    .then_some(Message::DeviceDebugStreamSave),
+            )
+            .padding([4, 10])
+            .style(crate::styles::nav_button);
+
+        column![
+            text("DEBUG BUS-TRACE STREAM (U64 only)")
+                .size(fs.normal)
+                .color(iced::Color::from_rgb(0.7, 0.72, 0.8)),
+            row![start_stop, save_btn, Space::new().width(12), stats]
+                .spacing(8)
+                .align_y(iced::Alignment::Center),
+            text(
+                "Cycle-accurate 6510/VIC/1541 bus trace. Mutually exclusive with the \
+                 VIC video stream. Saved as a raw capture (.bin) for the documented \
+                 GtkWave/VCD converter — the sample layout is FPGA-defined and not \
+                 decoded here."
+            )
+            .size(fs.tiny)
+            .color(iced::Color::from_rgb(0.55, 0.55, 0.6)),
+        ]
+        .spacing(8)
+        .into()
+    }
+
+    /// DEVICE tab — drive control, keyboard injection, and the debug
+    /// register. Groups low-level device capabilities the REST API exposes
+    /// but that don't fit the file/music/config tabs.
+    fn view_device(&self) -> Element<'_, Message> {
+        let fs = crate::styles::FontSizes::from_base(self.settings.preferences.font_size);
+        let connected = self.status.connected;
+
+        // One drive's control cluster: mode switch + power + reset.
+        let drive_row = |label: &'static str, drive: &'static str| -> Element<'_, Message> {
+            let mode_btn =
+                |mode: &'static str| {
+                    button(text(mode).size(fs.small))
+                        .on_press_maybe(connected.then(|| {
+                            Message::DeviceSetDriveMode(drive.to_string(), mode.to_string())
+                        }))
+                        .padding([3, 8])
+                        .style(crate::styles::nav_button)
+                };
+            row![
+                text(label).size(fs.normal).width(Length::Fixed(70.0)),
+                text("Mode:").size(fs.small),
+                mode_btn("1541"),
+                mode_btn("1571"),
+                mode_btn("1581"),
+                Space::new().width(12),
+                button(text("Power On").size(fs.small))
+                    .on_press_maybe(
+                        connected.then(|| Message::DeviceDrivePower(drive.to_string(), true)),
+                    )
+                    .padding([3, 8])
+                    .style(crate::styles::nav_button),
+                button(text("Power Off").size(fs.small))
+                    .on_press_maybe(
+                        connected.then(|| Message::DeviceDrivePower(drive.to_string(), false)),
+                    )
+                    .padding([3, 8])
+                    .style(crate::styles::nav_button),
+                button(text("Reset").size(fs.small))
+                    .on_press_maybe(connected.then(|| Message::DeviceDriveReset(drive.to_string())))
+                    .padding([3, 8])
+                    .style(crate::styles::nav_button),
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center)
+            .into()
+        };
+
+        let drive_section = column![
+            text("DRIVE CONTROL")
+                .size(fs.normal)
+                .color(iced::Color::from_rgb(0.7, 0.72, 0.8)),
+            drive_row("Drive A", "a"),
+            drive_row("Drive B", "b"),
+        ]
+        .spacing(8);
+
+        // Keyboard injection — type into the running C64 (BASIC or any prompt).
+        let keyboard_section = column![
+            text("KEYBOARD INPUT (KERNAL buffer)")
+                .size(fs.normal)
+                .color(iced::Color::from_rgb(0.7, 0.72, 0.8)),
+            row![
+                text_input("text to type into the C64…", &self.device_keyboard_input)
+                    .on_input(Message::DeviceKeyboardInputChanged)
+                    .on_submit(Message::DeviceSendKeys)
+                    .size(fs.small)
+                    .padding(4)
+                    .width(Length::Fixed(360.0)),
+                button(text("Send Keys").size(fs.small))
+                    .on_press_maybe(connected.then_some(Message::DeviceSendKeys))
+                    .padding([4, 10])
+                    .style(crate::styles::action_button),
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+            text(
+                "Feeds text into the KERNAL keyboard buffer ($0277) and presses RETURN — \
+                  works at the BASIC prompt and programs that read via the KERNAL (GETIN). \
+                  Games that scan the keyboard matrix ($DC00) directly won't see it."
+            )
+            .size(fs.tiny)
+            .color(iced::Color::from_rgb(0.55, 0.55, 0.6)),
+        ]
+        .spacing(8);
+
+        // Debug register ($D7FF) — U64 only.
+        let debugreg_current = match self.device_debugreg_value {
+            Some(v) => format!("${:02X} ({})", v, v),
+            None => "—".to_string(),
+        };
+        let debugreg_section = column![
+            text("DEBUG REGISTER ($D7FF · U64 only)")
+                .size(fs.normal)
+                .color(iced::Color::from_rgb(0.7, 0.72, 0.8)),
+            row![
+                button(text("Read").size(fs.small))
+                    .on_press_maybe(connected.then_some(Message::DeviceReadDebugReg))
+                    .padding([4, 10])
+                    .style(crate::styles::nav_button),
+                text(format!("Current: {}", debugreg_current)).size(fs.small),
+                Space::new().width(16),
+                text("Write hex:").size(fs.small),
+                text_input("00", &self.device_debugreg_input)
+                    .on_input(Message::DeviceDebugRegInputChanged)
+                    .on_submit(Message::DeviceWriteDebugReg)
+                    .size(fs.small)
+                    .padding(4)
+                    .width(Length::Fixed(70.0)),
+                button(text("Write").size(fs.small))
+                    .on_press_maybe(connected.then_some(Message::DeviceWriteDebugReg))
+                    .padding([4, 10])
+                    .style(crate::styles::action_button),
+            ]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+        ]
+        .spacing(8);
+
+        let gate = if connected {
+            text("")
+        } else {
+            text("Not connected — device controls are disabled.")
+                .size(fs.small)
+                .color(iced::Color::from_rgb(0.8, 0.4, 0.0))
+        };
+
+        let content = column![
+            text("DEVICE CONTROLS").size(fs.large),
+            gate,
+            rule::horizontal(1),
+            drive_section,
+            rule::horizontal(1),
+            keyboard_section,
+            rule::horizontal(1),
+            debugreg_section,
+            rule::horizontal(1),
+            self.view_debug_stream_section(),
+        ]
+        .spacing(16)
+        .padding(10);
+
+        scrollable(content).height(Length::Fill).into()
     }
 
     fn view_status_bar(&self) -> Element<'_, Message> {

--- a/src/music_ops.rs
+++ b/src/music_ops.rs
@@ -186,6 +186,174 @@ pub async fn load_playlist_async() -> Result<Vec<PlaylistEntry>, String> {
     Ok(playlist.entries)
 }
 
+/// True if `path` has a music extension we can play (SID, MOD, PRG).
+fn is_music_path(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_lowercase())
+            .as_deref(),
+        Some("sid") | Some("mod") | Some("prg")
+    )
+}
+
+/// Resolve a playlist line to an absolute path. Absolute paths are kept
+/// as-is; relative paths are joined against `base_dir` (the directory the
+/// playlist file lives in). `http(s)://` URLs return None (unsupported).
+fn resolve_playlist_path(raw: &str, base_dir: &Path) -> Option<PathBuf> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let lower = raw.to_lowercase();
+    if lower.starts_with("http://") || lower.starts_with("https://") {
+        log::warn!("Skipping unsupported URL in playlist: {}", raw);
+        return None;
+    }
+    let p = PathBuf::from(raw);
+    Some(if p.is_absolute() { p } else { base_dir.join(p) })
+}
+
+/// Turn a list of resolved candidate paths into the subset that exists and
+/// is a playable music file, logging (and counting) anything skipped.
+fn keep_existing_music(candidates: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut skipped = 0usize;
+    for c in candidates {
+        if is_music_path(&c) && c.is_file() {
+            out.push(c);
+        } else {
+            skipped += 1;
+            log::warn!(
+                "Playlist import: skipping missing/unsupported entry: {}",
+                c.display()
+            );
+        }
+    }
+    if skipped > 0 {
+        log::info!("Playlist import: skipped {} entr(y/ies)", skipped);
+    }
+    out
+}
+
+/// Import an M3U/M3U8 playlist. Returns resolved, existing music-file paths.
+/// `#`-comment lines (including `#EXTINF`) are ignored — entries are rebuilt
+/// with authoritative metadata on the app side.
+pub async fn import_m3u_async() -> Result<Vec<PathBuf>, String> {
+    let handle = rfd::AsyncFileDialog::new()
+        .add_filter("M3U Playlist", &["m3u", "m3u8"])
+        .pick_file()
+        .await
+        .ok_or("Import cancelled")?;
+
+    let path = handle.path().to_path_buf();
+    let base_dir = path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let content = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("Read error: {}", e))?;
+
+    let candidates: Vec<PathBuf> = content
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .filter_map(|l| resolve_playlist_path(l, &base_dir))
+        .collect();
+
+    let paths = keep_existing_music(candidates);
+    if paths.is_empty() {
+        return Err("No playable files found in M3U".to_string());
+    }
+    Ok(paths)
+}
+
+/// Import a PLS playlist (INI-style `FileN=path`). Returns resolved, existing
+/// music-file paths in entry order.
+pub async fn import_pls_async() -> Result<Vec<PathBuf>, String> {
+    let handle = rfd::AsyncFileDialog::new()
+        .add_filter("PLS Playlist", &["pls"])
+        .pick_file()
+        .await
+        .ok_or("Import cancelled")?;
+
+    let path = handle.path().to_path_buf();
+    let base_dir = path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let content = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("Read error: {}", e))?;
+
+    // Collect (index, path) from `FileN=...` lines, then order by N.
+    let mut indexed: Vec<(u32, PathBuf)> = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        let lower = line.to_lowercase();
+        if !lower.starts_with("file") {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        // key looks like "File1", "File12" — parse the trailing number.
+        let n: u32 = key[4..].trim().parse().unwrap_or(u32::MAX);
+        if let Some(p) = resolve_playlist_path(value, &base_dir) {
+            indexed.push((n, p));
+        }
+    }
+    indexed.sort_by_key(|(n, _)| *n);
+
+    let paths = keep_existing_music(indexed.into_iter().map(|(_, p)| p).collect());
+    if paths.is_empty() {
+        return Err("No playable files found in PLS".to_string());
+    }
+    Ok(paths)
+}
+
+/// Export the current playlist as an extended M3U file (`#EXTM3U` +
+/// `#EXTINF:<secs>,<name>` per track, followed by the absolute path).
+pub async fn export_m3u_async(
+    playlist: SavedPlaylist,
+    default_duration: u32,
+) -> Result<String, String> {
+    let handle = rfd::AsyncFileDialog::new()
+        .add_filter("M3U Playlist", &["m3u"])
+        .set_file_name(&format!("{}.m3u", playlist.name))
+        .save_file()
+        .await
+        .ok_or("Export cancelled")?;
+
+    let path = handle.path().to_path_buf();
+
+    let mut out = String::from("#EXTM3U\n");
+    for entry in &playlist.entries {
+        let secs = entry.duration.unwrap_or(default_duration);
+        let name = if entry.name.is_empty() {
+            entry
+                .path
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_else(|| "Unknown".to_string())
+        } else {
+            entry.name.clone()
+        };
+        out.push_str(&format!("#EXTINF:{},{}\n", secs, name));
+        out.push_str(&entry.path.to_string_lossy());
+        out.push('\n');
+    }
+
+    tokio::fs::write(&path, out)
+        .await
+        .map_err(|e| format!("Write error: {}", e))?;
+
+    Ok(path.to_string_lossy().to_string())
+}
+
 /// Search for music files (SID, MOD, PRG) recursively under `root`, matching
 /// filenames or directory names against `query` (case-insensitive).
 /// Returns BrowserEntry items with names showing relative paths from root.
@@ -318,5 +486,46 @@ pub fn format_total_duration(entries: &[PlaylistEntry], default_duration: u32) -
         format!("{}h {}m {}s", hours, minutes, seconds)
     } else {
         format!("{}m {}s", minutes, seconds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_absolute_path_kept_as_is() {
+        let base = Path::new("/music/lists");
+        let abs = if cfg!(windows) {
+            "C:\\games\\a.sid"
+        } else {
+            "/games/a.sid"
+        };
+        let got = resolve_playlist_path(abs, base).unwrap();
+        assert_eq!(got, PathBuf::from(abs));
+    }
+
+    #[test]
+    fn resolve_relative_path_joined_against_base() {
+        let base = Path::new("/music/lists");
+        let got = resolve_playlist_path("sub/tune.sid", base).unwrap();
+        assert_eq!(got, PathBuf::from("/music/lists/sub/tune.sid"));
+    }
+
+    #[test]
+    fn resolve_url_is_skipped() {
+        let base = Path::new("/music");
+        assert!(resolve_playlist_path("http://example.com/x.sid", base).is_none());
+        assert!(resolve_playlist_path("HTTPS://example.com/x.sid", base).is_none());
+        assert!(resolve_playlist_path("   ", base).is_none());
+    }
+
+    #[test]
+    fn is_music_path_matches_known_extensions() {
+        assert!(is_music_path(Path::new("a.sid")));
+        assert!(is_music_path(Path::new("a.MOD")));
+        assert!(is_music_path(Path::new("a.Prg")));
+        assert!(!is_music_path(Path::new("a.txt")));
+        assert!(!is_music_path(Path::new("a")));
     }
 }

--- a/src/music_player.rs
+++ b/src/music_player.rs
@@ -92,6 +92,12 @@ pub enum MusicPlayerMessage {
     PlaylistSaved(Result<String, String>),
     PlaylistLoaded(Result<Vec<PlaylistEntry>, String>),
     PlaylistNameChanged(String),
+    // Playlist import/export (M3U/PLS)
+    ImportM3U,
+    ImportPLS,
+    ExportM3U,
+    /// Resolved music-file paths from an M3U/PLS import — appended (deduped)
+    PlaylistImported(Result<Vec<PathBuf>, String>),
 
     // Song length database
     DownloadSongLengths,
@@ -854,6 +860,48 @@ impl MusicPlayer {
                 Task::none()
             }
 
+            MusicPlayerMessage::ImportM3U => Task::perform(
+                music_ops::import_m3u_async(),
+                MusicPlayerMessage::PlaylistImported,
+            ),
+
+            MusicPlayerMessage::ImportPLS => Task::perform(
+                music_ops::import_pls_async(),
+                MusicPlayerMessage::PlaylistImported,
+            ),
+
+            MusicPlayerMessage::ExportM3U => {
+                let playlist = SavedPlaylist {
+                    name: self.playlist_name.clone(),
+                    entries: self.playlist.clone(),
+                };
+                let default_duration = self.default_song_duration;
+                Task::perform(
+                    music_ops::export_m3u_async(playlist, default_duration),
+                    MusicPlayerMessage::PlaylistSaved,
+                )
+            }
+
+            MusicPlayerMessage::PlaylistImported(result) => {
+                match result {
+                    Ok(paths) => {
+                        let (added, skipped) = self.append_music_paths(paths);
+                        self.status_message = if skipped > 0 {
+                            format!(
+                                "Imported {} track(s), {} duplicate(s) skipped",
+                                added, skipped
+                            )
+                        } else {
+                            format!("Imported {} track(s)", added)
+                        };
+                    }
+                    Err(e) => {
+                        self.status_message = format!("Import failed: {}", e);
+                    }
+                }
+                Task::none()
+            }
+
             // === Song Length Database ===
             MusicPlayerMessage::DownloadSongLengths => {
                 self.song_lengths_status = "Downloading song lengths database...".to_string();
@@ -1365,6 +1413,26 @@ impl MusicPlayer {
             );
         }
 
+        // "Up Next" strip — shows the next few tracks in true play order
+        // (honors shuffle + repeat). Each is clickable to jump straight to it.
+        let upcoming = self.upcoming_indices(3);
+        if !upcoming.is_empty() {
+            let mut up_next = row![text("Up Next:")
+                .size(fs.small)
+                .color(iced::Color::from_rgb(0.6, 0.7, 0.8))]
+            .spacing(6)
+            .align_y(iced::Alignment::Center);
+            for idx in upcoming {
+                up_next = up_next.push(
+                    button(text(self.short_track_label(idx)).size(fs.small))
+                        .on_press(MusicPlayerMessage::PlaylistItemDoubleClick(idx))
+                        .padding([2, 6])
+                        .style(crate::styles::nav_button),
+                );
+            }
+            top_bar_items.push(up_next.into());
+        }
+
         top_bar_items.push(
             row![transport, Space::new().width(20), modes]
                 .align_y(iced::Alignment::Center)
@@ -1693,6 +1761,36 @@ impl MusicPlayer {
                     .style(crate::styles::subtle_tooltip),
                 ]
                 .spacing(5),
+                row![
+                    tooltip(
+                        button(text("+M3U").size(fs.small))
+                            .on_press(MusicPlayerMessage::ImportM3U)
+                            .padding([3, 6])
+                            .style(crate::styles::nav_button),
+                        "Import an M3U/M3U8 playlist (appended, duplicates skipped)",
+                        tooltip::Position::Bottom,
+                    )
+                    .style(crate::styles::subtle_tooltip),
+                    tooltip(
+                        button(text("+PLS").size(fs.small))
+                            .on_press(MusicPlayerMessage::ImportPLS)
+                            .padding([3, 6])
+                            .style(crate::styles::nav_button),
+                        "Import a PLS playlist (appended, duplicates skipped)",
+                        tooltip::Position::Bottom,
+                    )
+                    .style(crate::styles::subtle_tooltip),
+                    tooltip(
+                        button(text("→M3U").size(fs.small))
+                            .on_press(MusicPlayerMessage::ExportM3U)
+                            .padding([3, 6])
+                            .style(crate::styles::nav_button),
+                        "Export the playlist as an extended M3U file",
+                        tooltip::Position::Bottom,
+                    )
+                    .style(crate::styles::subtle_tooltip),
+                ]
+                .spacing(5),
                 text(format!(
                     "{} tracks | Total: {}",
                     self.playlist.len(),
@@ -1961,6 +2059,39 @@ impl MusicPlayer {
 
     // Helper methods
 
+    /// Append imported music-file paths to the playlist, building full
+    /// entries via `create_playlist_entry` and skipping duplicates (same
+    /// path already present). Returns (added, skipped_as_duplicate).
+    fn append_music_paths(&mut self, paths: Vec<PathBuf>) -> (usize, usize) {
+        let mut added = 0usize;
+        let mut skipped = 0usize;
+        for path in paths {
+            if self.playlist.iter().any(|e| e.path == path) {
+                skipped += 1;
+                continue;
+            }
+            let Some(file_type) = music_type_from_path(&path) else {
+                skipped += 1;
+                continue;
+            };
+            let name = path
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_else(|| "Unknown".to_string());
+            let browser_entry = BrowserEntry {
+                path,
+                name,
+                entry_type: BrowserEntryType::MusicFile(file_type.clone()),
+                subsongs: 1,
+                sid_tooltip: None,
+            };
+            let entry = self.create_playlist_entry(&browser_entry, file_type);
+            self.playlist.push(entry);
+            added += 1;
+        }
+        (added, skipped)
+    }
+
     fn create_playlist_entry(
         &self,
         browser_entry: &BrowserEntry,
@@ -2143,6 +2274,66 @@ impl MusicPlayer {
         );
     }
 
+    /// Return up to `n` playlist indices that will play *after* the current
+    /// track, in true play order — honoring shuffle order and repeat
+    /// wrap-around. Drives the "Up Next" strip in the view.
+    fn upcoming_indices(&self, n: usize) -> Vec<usize> {
+        if self.playlist.is_empty() || n == 0 {
+            return Vec::new();
+        }
+        // Traversal order matches next_track(): shuffle_order when shuffling,
+        // otherwise sequential 0..len.
+        let order: Vec<usize> = if self.shuffle_enabled && !self.shuffle_order.is_empty() {
+            self.shuffle_order.clone()
+        } else {
+            (0..self.playlist.len()).collect()
+        };
+        let len = order.len();
+        // Position just after the current track within `order`.
+        let start_pos = match self.current_playing {
+            Some(cur) => order
+                .iter()
+                .position(|&x| x == cur)
+                .map(|p| p + 1)
+                .unwrap_or(0),
+            None => 0,
+        };
+        let mut out = Vec::new();
+        let mut i = 0;
+        while out.len() < n && i < len {
+            let pos = start_pos + i;
+            if !self.repeat_enabled && pos >= len {
+                break; // no wrap when repeat is off
+            }
+            let entry = order[pos % len];
+            // Skip the current track itself (can recur when wrapping under repeat).
+            if Some(entry) != self.current_playing {
+                out.push(entry);
+            }
+            i += 1;
+        }
+        out
+    }
+
+    /// Compact display label for a playlist entry (name or filename,
+    /// truncated) — used by the "Up Next" strip.
+    fn short_track_label(&self, idx: usize) -> String {
+        match self.playlist.get(idx) {
+            Some(e) => {
+                let n = if e.name.is_empty() {
+                    e.path
+                        .file_name()
+                        .map(|s| s.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "?".to_string())
+                } else {
+                    e.name.clone()
+                };
+                truncate_string(&n, 18)
+            }
+            None => String::new(),
+        }
+    }
+
     fn next_track(&mut self) {
         if self.playlist.is_empty() {
             self.current_playing = None;
@@ -2284,6 +2475,21 @@ fn search_files_recursive(root: &Path, query: &str) -> Vec<BrowserEntry> {
 }
 
 // === Helper Functions ===
+
+/// Map a file path's extension to a playable `MusicFileType`, if any.
+fn music_type_from_path(path: &Path) -> Option<MusicFileType> {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .as_deref()
+    {
+        Some("sid") => Some(MusicFileType::Sid),
+        Some("mod") => Some(MusicFileType::Mod),
+        Some("prg") => Some(MusicFileType::Prg),
+        _ => None,
+    }
+}
 
 fn truncate_string(s: &str, max_len: usize) -> String {
     crate::string_utils::truncate_string(s, max_len)

--- a/src/remote_browser.rs
+++ b/src/remote_browser.rs
@@ -33,6 +33,7 @@ pub enum RemoteBrowserMessage {
     UploadDirectoryComplete(Result<String, String>),
     // Runners - execute files on Ultimate64
     RunPrg(String),
+    LoadPrg(String),
     RunCrt(String),
     PlaySid(String),
     PlayMod(String),
@@ -518,6 +519,21 @@ impl RemoteBrowser {
                     let password = self.password.clone();
                     Task::perform(
                         async move { api::run_prg(&host, &path, password).await },
+                        RemoteBrowserMessage::RunnerComplete,
+                    )
+                } else {
+                    self.status_message = Some("Not connected".to_string());
+                    Task::none()
+                }
+            }
+
+            RemoteBrowserMessage::LoadPrg(path) => {
+                if let Some(host) = &self.host_address {
+                    self.status_message = Some("Loading PRG...".to_string());
+                    let host = host.clone();
+                    let password = self.password.clone();
+                    Task::perform(
+                        async move { api::load_prg_async(&host, &path, password.as_deref()).await },
                         RemoteBrowserMessage::RunnerComplete,
                     )
                 } else {
@@ -1759,15 +1775,27 @@ impl RemoteBrowser {
                 let action_button: Element<'_, RemoteBrowserMessage> = if entry.is_dir {
                     Space::new().width(0).into()
                 } else if ext.ends_with(".prg") {
-                    tooltip(
-                        button(text("Run").size(small))
-                            .on_press(RemoteBrowserMessage::RunPrg(entry.path.clone()))
-                            .padding([2, 8])
-                            .style(crate::styles::action_button),
-                        "Load and run PRG file",
-                        tooltip::Position::Top,
-                    )
-                    .style(crate::styles::subtle_tooltip)
+                    row![
+                        tooltip(
+                            button(text("Run").size(small))
+                                .on_press(RemoteBrowserMessage::RunPrg(entry.path.clone()))
+                                .padding([2, 8])
+                                .style(crate::styles::action_button),
+                            "Load and run PRG file",
+                            tooltip::Position::Top,
+                        )
+                        .style(crate::styles::subtle_tooltip),
+                        tooltip(
+                            button(text("Load").size(small))
+                                .on_press(RemoteBrowserMessage::LoadPrg(entry.path.clone()))
+                                .padding([2, 8])
+                                .style(crate::styles::nav_button),
+                            "Load PRG into memory without running",
+                            tooltip::Position::Top,
+                        )
+                        .style(crate::styles::subtle_tooltip),
+                    ]
+                    .spacing(4)
                     .into()
                 } else if ext.ends_with(".crt") {
                     tooltip(


### PR DESCRIPTION
**File browser**

- Local file rename (F2 on the local pane) — was a dead info toast, now a real rename dialog
**Music player**

- "Up Next" queue strip (next tracks in true play order, honors shuffle/repeat, clickable)
- M3U/M3U8 import
- PLS import
- M3U export
- Duplicate skipping on import

**Device tab (new)**

- Live drive-type switching (1541 / 1571 / 1581) for Drive A/B
- Drive power on/off (A/B)
- Drive reset (A/B)
- Keyboard/text injection into the KERNAL buffer (BASIC prompt / GETIN only — not games)
- Debug register $D7FF read/write (U64)
- Debug bus-trace stream capture → raw .bin file (U64)
**Remote browser**

- Load PRG without running (Load button next to Run)
