### PR TITLE
refactor: typed DeviceError + central device_send for the REST layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "ultimate64-manager"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultimate64-manager"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "Ultimate64 Manager - Control your Ultimate64/Ultimate-II+"
 authors = ["Marcin Spoczynski"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,7 @@
 // Ultimate64 REST API client
 
+use crate::device_error::DeviceError;
 use crate::net_utils::REST_TIMEOUT_SECS;
-use reqwest::Client;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -57,29 +57,15 @@ async fn run_file(
     let url = format!("http://{}:80/v1/runners:{}", host, runner);
     log::info!("API: {} -> {}", runner, file_path);
 
-    let client = Client::new();
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let request = crate::net_utils::with_password(
+        client.put(&url).query(&[("file", file_path)]),
+        password.as_deref(),
+    );
+    crate::net_utils::device_send(request).await?;
 
-    // Build request with file query parameter
-    let mut request = client.put(&url).query(&[("file", file_path)]);
-
-    // Add X-password header if password is configured
-    if let Some(ref pwd) = password {
-        if !pwd.is_empty() {
-            request = request.header("X-password", pwd.as_str());
-        }
-    }
-
-    let response = request
-        .send()
-        .await
-        .map_err(|e| format!("HTTP request failed: {}", e))?;
-
-    if response.status().is_success() {
-        let filename = file_path.rsplit('/').next().unwrap_or(file_path);
-        Ok(format!("{}: {}", runner_description(runner), filename))
-    } else {
-        Err(format!("Runner failed: HTTP {}", response.status()))
-    }
+    let filename = file_path.rsplit('/').next().unwrap_or(file_path);
+    Ok(format!("{}: {}", runner_description(runner), filename))
 }
 
 fn runner_description(runner: &str) -> &'static str {
@@ -104,29 +90,17 @@ pub async fn mount_disk(
     let url = format!("http://{}:80/v1/drives/{}:mount", host, drive);
     log::info!("API: mount {} to drive {} ({})", file_path, drive, mode);
 
-    let client = Client::new();
-    let mut request = client
-        .put(&url)
-        .query(&[("image", file_path), ("mode", mode)]);
+    let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
+    let request = crate::net_utils::with_password(
+        client
+            .put(&url)
+            .query(&[("image", file_path), ("mode", mode)]),
+        password.as_deref(),
+    );
+    crate::net_utils::device_send(request).await?;
 
-    // Add X-password header if password is configured
-    if let Some(ref pwd) = password {
-        if !pwd.is_empty() {
-            request = request.header("X-password", pwd.as_str());
-        }
-    }
-
-    let response = request
-        .send()
-        .await
-        .map_err(|e| format!("HTTP request failed: {}", e))?;
-
-    if response.status().is_success() {
-        let filename = file_path.rsplit('/').next().unwrap_or(file_path);
-        Ok(format!("Mounted: {}", filename))
-    } else {
-        Err(format!("Mount failed: HTTP {}", response.status()))
-    }
+    let filename = file_path.rsplit('/').next().unwrap_or(file_path);
+    Ok(format!("Mounted: {}", filename))
 }
 
 /// Run a disk image with full sequence: mount, reset, LOAD"*",8,1, RUN
@@ -362,9 +336,7 @@ pub async fn reset_machine_async(host: &str, password: Option<&str>) -> Result<(
     let url = format!("{}/v1/machine:reset", host);
     let client = crate::net_utils::build_device_client(5)?;
     let req = crate::net_utils::with_password(client.put(&url), password);
-    req.send()
-        .await
-        .map_err(|e| format!("Reset failed: {}", e))?;
+    crate::net_utils::device_send(req).await?;
     Ok(())
 }
 
@@ -396,9 +368,9 @@ async fn writemem_once(
     address: u16,
     data: Vec<u8>,
     password: Option<&str>,
-) -> Result<(), String> {
+) -> Result<(), DeviceError> {
     let url = format!("{}/v1/machine:writemem?address={:x}", host, address);
-    let client = crate::net_utils::build_device_client(5)?;
+    let client = crate::net_utils::build_device_client(5).map_err(DeviceError::Build)?;
     let req = crate::net_utils::with_password(
         client
             .post(&url)
@@ -406,25 +378,8 @@ async fn writemem_once(
             .body(data),
         password,
     );
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| format!("writemem failed: {}", e))?;
-    if !resp.status().is_success() {
-        return Err(format!("writemem HTTP {}", resp.status()));
-    }
+    crate::net_utils::device_send(req).await?;
     Ok(())
-}
-
-fn is_transient_err(e: &str) -> bool {
-    let s = e.to_lowercase();
-    s.contains("empty reply")
-        || s.contains("connection")
-        || s.contains("reset")
-        || s.contains("broken")
-        || s.contains("eof")
-        || s.contains("timed out")
-        || s.contains("deadline")
 }
 
 /// writemem with retries on transient errors (DMA contention, cart activity).
@@ -434,7 +389,7 @@ pub async fn writemem_async(
     data: Vec<u8>,
     password: Option<&str>,
 ) -> Result<(), String> {
-    let mut last_err = String::new();
+    let mut last_err: Option<DeviceError> = None;
     for attempt in 0..4 {
         if attempt > 0 {
             let delay = 500 + 500 * attempt as u64;
@@ -444,16 +399,17 @@ pub async fn writemem_async(
         match writemem_once(host, address, data.clone(), password).await {
             Ok(()) => return Ok(()),
             Err(e) => {
-                if !is_transient_err(&e) {
-                    return Err(e);
+                if !e.is_transient() {
+                    return Err(e.to_string());
                 }
-                last_err = e;
+                last_err = Some(e);
             }
         }
     }
     Err(format!(
         "writemem 0x{:x} failed after 4 attempts: {}",
-        address, last_err
+        address,
+        last_err.map(|e| e.to_string()).unwrap_or_default()
     ))
 }
 
@@ -515,13 +471,9 @@ pub async fn upload_mount_disk_async(
     let url = format!("{}/v1/drives/{}:mount", host, drive);
     let client = crate::net_utils::build_device_client(60)?;
     let req = crate::net_utils::with_password(client.post(&url).multipart(form), password);
-    let resp = req
-        .send()
+    crate::net_utils::device_send(req)
         .await
         .map_err(|e| format!("Upload+mount failed: {}", e))?;
-    if !resp.status().is_success() {
-        return Err(format!("mount HTTP {}", resp.status()));
-    }
     Ok(())
 }
 
@@ -540,17 +492,9 @@ pub async fn unmount_disk_async(
     let url = format!("{}/v1/drives/{}:remove", host, drive);
     let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
     let req = crate::net_utils::with_password(client.put(&url), password);
-    let resp = req
-        .send()
+    crate::net_utils::device_send(req)
         .await
         .map_err(|e| format!("unmount Drive {}: {}", drive.to_uppercase(), e))?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "unmount Drive {}: HTTP {}",
-            drive.to_uppercase(),
-            resp.status()
-        ));
-    }
     Ok(())
 }
 
@@ -569,13 +513,9 @@ pub async fn upload_runner_async(
             .body(data),
         password,
     );
-    let resp = req
-        .send()
+    crate::net_utils::device_send(req)
         .await
-        .map_err(|e| format!("{} failed: {}", runner, e))?;
-    if !resp.status().is_success() {
-        return Err(format!("{} HTTP {}", runner, resp.status()));
-    }
+        .map_err(|e| format!("{}: {}", runner, e))?;
     Ok(())
 }
 
@@ -596,17 +536,9 @@ pub async fn set_drive_mode_async(
     let url = format!("{}/v1/drives/{}:set_mode", host, drive);
     let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
     let req = crate::net_utils::with_password(client.put(&url).query(&[("mode", mode)]), password);
-    let resp = req
-        .send()
+    crate::net_utils::device_send(req)
         .await
         .map_err(|e| format!("Drive {} set mode: {}", drive.to_uppercase(), e))?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "Drive {} set mode: HTTP {}",
-            drive.to_uppercase(),
-            resp.status()
-        ));
-    }
     Ok(format!("Drive {} → {}", drive.to_uppercase(), mode))
 }
 
@@ -622,18 +554,9 @@ pub async fn drive_power_async(
     let url = format!("{}/v1/drives/{}:{}", host, drive, action);
     let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
     let req = crate::net_utils::with_password(client.put(&url), password);
-    let resp = req
-        .send()
+    crate::net_utils::device_send(req)
         .await
         .map_err(|e| format!("Drive {} power {}: {}", drive.to_uppercase(), action, e))?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "Drive {} power {}: HTTP {}",
-            drive.to_uppercase(),
-            action,
-            resp.status()
-        ));
-    }
     Ok(format!("Drive {} powered {}", drive.to_uppercase(), action))
 }
 
@@ -647,17 +570,9 @@ pub async fn drive_reset_async(
     let url = format!("{}/v1/drives/{}:reset", host, drive);
     let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
     let req = crate::net_utils::with_password(client.put(&url), password);
-    let resp = req
-        .send()
+    crate::net_utils::device_send(req)
         .await
         .map_err(|e| format!("Drive {} reset: {}", drive.to_uppercase(), e))?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "Drive {} reset: HTTP {}",
-            drive.to_uppercase(),
-            resp.status()
-        ));
-    }
     Ok(format!("Drive {} reset", drive.to_uppercase()))
 }
 
@@ -672,13 +587,9 @@ pub async fn load_prg_async(
     let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
     let req =
         crate::net_utils::with_password(client.put(&url).query(&[("file", file_path)]), password);
-    let resp = req
-        .send()
+    crate::net_utils::device_send(req)
         .await
-        .map_err(|e| format!("load_prg failed: {}", e))?;
-    if !resp.status().is_success() {
-        return Err(format!("load_prg HTTP {}", resp.status()));
-    }
+        .map_err(|e| format!("load_prg: {}", e))?;
     let filename = file_path.rsplit('/').next().unwrap_or(file_path);
     Ok(format!("Loaded: {}", filename))
 }
@@ -689,13 +600,9 @@ pub async fn read_debugreg_async(host: &str, password: Option<&str>) -> Result<u
     let url = format!("{}/v1/machine:debugreg", host);
     let client = crate::net_utils::build_device_client(REST_TIMEOUT_SECS)?;
     let req = crate::net_utils::with_password(client.get(&url), password);
-    let resp = req
-        .send()
+    let resp = crate::net_utils::device_send(req)
         .await
         .map_err(|e| format!("debugreg read: {}", e))?;
-    if !resp.status().is_success() {
-        return Err(format!("debugreg read HTTP {}", resp.status()));
-    }
     let body = resp
         .text()
         .await
@@ -718,13 +625,9 @@ pub async fn write_debugreg_async(
         client.put(&url).query(&[("value", value_str.as_str())]),
         password,
     );
-    let resp = req
-        .send()
+    crate::net_utils::device_send(req)
         .await
         .map_err(|e| format!("debugreg write: {}", e))?;
-    if !resp.status().is_success() {
-        return Err(format!("debugreg write HTTP {}", resp.status()));
-    }
     Ok(format!("Debug register = ${:02X}", value))
 }
 

--- a/src/app/connection.rs
+++ b/src/app/connection.rs
@@ -120,7 +120,7 @@ impl Ultimate64Browser {
 
     pub(crate) fn handle_status_updated(
         &mut self,
-        result: Result<StatusInfo, String>,
+        result: Result<StatusInfo, crate::device_error::DeviceError>,
         ctx: TabContext,
     ) -> Task<Message> {
         match result {
@@ -159,6 +159,26 @@ impl Ultimate64Browser {
                 // legitimately takes it offline for 15-30 seconds.
                 if self.device_profile_manager.is_loading {
                     log::debug!("Ignoring status failure during profile operation");
+                    return Task::none();
+                }
+
+                // A wrong/missing network password won't fix itself by retrying,
+                // so skip the transient-outage grace period and surface it
+                // immediately with an actionable message.
+                if e == crate::device_error::DeviceError::Unauthorized {
+                    log::warn!("Status poll unauthorized — bad network password");
+                    self.consecutive_status_failures =
+                        self.consecutive_status_failures.saturating_add(1);
+                    self.status.connected = false;
+                    self.status.device_info = None;
+                    self.user_message = Some(UserMessage::Error(
+                        "Unauthorized — check the device network password (Settings).".to_string(),
+                    ));
+                    if self.video_streaming.is_streaming {
+                        let _ = self
+                            .video_streaming
+                            .update(StreamingMessage::StopStream, ctx.clone());
+                    }
                     return Task::none();
                 }
 

--- a/src/config_api.rs
+++ b/src/config_api.rs
@@ -16,14 +16,7 @@ pub async fn fetch_categories(
 
     let request = crate::net_utils::with_password(client.get(&url), password.as_deref());
 
-    let response = request
-        .send()
-        .await
-        .map_err(|e| format!("Request failed: {}", e))?;
-
-    if !response.status().is_success() {
-        return Err(format!("HTTP error: {}", response.status()));
-    }
+    let response = crate::net_utils::device_send(request).await?;
 
     let text = response
         .text()
@@ -101,14 +94,7 @@ pub async fn fetch_category_items(
 
     let request = crate::net_utils::with_password(client.get(&url), password.as_deref());
 
-    let response = request
-        .send()
-        .await
-        .map_err(|e| format!("Request failed: {}", e))?;
-
-    if !response.status().is_success() {
-        return Err(format!("HTTP error: {}", response.status()));
-    }
+    let response = crate::net_utils::device_send(request).await?;
 
     let text = response
         .text()
@@ -235,14 +221,7 @@ pub async fn fetch_item_details(
 
     let request = crate::net_utils::with_password(client.get(&url), password.as_deref());
 
-    let response = request
-        .send()
-        .await
-        .map_err(|e| format!("Request failed: {}", e))?;
-
-    if !response.status().is_success() {
-        return Err(format!("HTTP error: {}", response.status()));
-    }
+    let response = crate::net_utils::device_send(request).await?;
 
     let text = response
         .text()
@@ -402,22 +381,15 @@ pub async fn flash_operation(
 
     let request = crate::net_utils::with_password(client.put(&url), password.as_deref());
 
-    let response = request
-        .send()
+    crate::net_utils::device_send(request)
         .await
-        .map_err(|e| format!("Request failed: {}", e))?;
+        .map_err(|e| format!("Flash operation failed: {}", e))?;
 
-    if response.status().is_success() {
-        match operation {
-            "save_to_flash" => Ok("Configuration saved to flash memory".to_string()),
-            "load_from_flash" => Ok("Configuration loaded from flash memory".to_string()),
-            "reset_to_default" => Ok("Configuration reset to factory defaults".to_string()),
-            _ => Ok("Operation completed".to_string()),
-        }
-    } else {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        Err(format!("Flash operation failed: {} - {}", status, text))
+    match operation {
+        "save_to_flash" => Ok("Configuration saved to flash memory".to_string()),
+        "load_from_flash" => Ok("Configuration loaded from flash memory".to_string()),
+        "reset_to_default" => Ok("Configuration reset to factory defaults".to_string()),
+        _ => Ok("Operation completed".to_string()),
     }
 }
 

--- a/src/device_error.rs
+++ b/src/device_error.rs
@@ -1,0 +1,129 @@
+//! Typed error for Ultimate64 device REST calls.
+//!
+//! The device REST modules (`api`, `config_api`, `profile_api`, …) historically
+//! returned `Result<_, String>`, which loses the distinction between "wrong
+//! password", "device offline (timeout)", and "not found" — a distinction the
+//! auto-reconnect / status logic actually needs. `DeviceError` classifies the
+//! failure once, at the HTTP boundary, via [`crate::net_utils::device_send`].
+//!
+//! For call sites that only surface a message, `impl From<DeviceError> for
+//! String` lets a `Result<_, DeviceError>` helper be used with `?` inside an
+//! existing `Result<_, String>` function — so adopting the typed error needs no
+//! churn at the ~100 UI call sites; they keep flattening to a string, while the
+//! paths that care (status/reconnect) can match on the variant.
+
+use std::fmt;
+
+/// A classified failure from a device REST request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeviceError {
+    /// No connection configured (host/URL missing).
+    NotConnected,
+    /// HTTP 403 — network password missing or wrong.
+    Unauthorized,
+    /// HTTP 404 — endpoint/resource not found.
+    NotFound,
+    /// Request exceeded its deadline (device likely offline or rebooting).
+    Timeout,
+    /// Any other non-success HTTP status.
+    Http(u16),
+    /// Transport/connection error (DNS, refused, reset, EOF, …).
+    Network(String),
+    /// Could not build the HTTP client.
+    Build(String),
+}
+
+impl DeviceError {
+    /// Map a non-success HTTP status code to a typed error.
+    pub fn from_status(code: u16) -> Self {
+        match code {
+            403 => DeviceError::Unauthorized,
+            404 => DeviceError::NotFound,
+            other => DeviceError::Http(other),
+        }
+    }
+
+    /// Classify a `reqwest` transport error (timeout vs. everything else).
+    pub fn from_reqwest(e: &reqwest::Error) -> Self {
+        if e.is_timeout() {
+            DeviceError::Timeout
+        } else {
+            DeviceError::Network(e.to_string())
+        }
+    }
+
+    /// Whether a retry might succeed — the device rebooting, DMA contention, or
+    /// the embedded HTTP server dropping an idle connection. Used by the
+    /// writemem retry loop and the transient-outage reconnect window.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            DeviceError::Timeout => true,
+            DeviceError::Http(502..=504) => true,
+            DeviceError::Network(msg) => {
+                let s = msg.to_lowercase();
+                s.contains("empty reply")
+                    || s.contains("connection")
+                    || s.contains("reset")
+                    || s.contains("broken")
+                    || s.contains("eof")
+                    || s.contains("timed out")
+                    || s.contains("deadline")
+            }
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Display for DeviceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeviceError::NotConnected => write!(f, "Not connected"),
+            DeviceError::Unauthorized => {
+                write!(f, "Unauthorized — check the device network password")
+            }
+            DeviceError::NotFound => write!(f, "Not found"),
+            DeviceError::Timeout => write!(f, "Request timed out — device may be offline"),
+            DeviceError::Http(code) => write!(f, "HTTP {}", code),
+            DeviceError::Network(msg) => write!(f, "Network error: {}", msg),
+            DeviceError::Build(msg) => write!(f, "HTTP client error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for DeviceError {}
+
+/// Flatten to a message. Lets a `DeviceError`-returning helper be used with `?`
+/// inside a `Result<_, String>` function without a manual `.map_err`.
+impl From<DeviceError> for String {
+    fn from(e: DeviceError) -> String {
+        e.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_classification() {
+        assert_eq!(DeviceError::from_status(403), DeviceError::Unauthorized);
+        assert_eq!(DeviceError::from_status(404), DeviceError::NotFound);
+        assert_eq!(DeviceError::from_status(500), DeviceError::Http(500));
+    }
+
+    #[test]
+    fn transient_detection() {
+        assert!(DeviceError::Timeout.is_transient());
+        assert!(DeviceError::Http(503).is_transient());
+        assert!(DeviceError::Network("connection reset by peer".into()).is_transient());
+        assert!(!DeviceError::Unauthorized.is_transient());
+        assert!(!DeviceError::Http(400).is_transient());
+        assert!(!DeviceError::Network("malformed body".into()).is_transient());
+    }
+
+    #[test]
+    fn flattens_to_string_via_from() {
+        let s: String = DeviceError::Unauthorized.into();
+        assert!(s.contains("password"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,7 @@ mod config_editor;
 mod config_presets;
 mod csdb_screenshots;
 mod debug_stream;
+mod device_error;
 mod device_profile;
 mod dir_preview;
 mod discovery;
@@ -134,6 +135,7 @@ mod video_scaling;
 use assembly64_browser::{Assembly64Browser, Assembly64BrowserMessage};
 use basic_editor::{BasicEditor, BasicEditorMessage};
 use config_editor::{ConfigEditor, ConfigEditorMessage};
+use device_error::DeviceError;
 use discovery::DiscoveredDevice;
 use file_browser::{FileBrowser, FileBrowserMessage};
 use memory_editor::{MemoryEditor, MemoryEditorMessage};
@@ -269,7 +271,7 @@ pub enum Message {
     DisconnectPressed,
     RefreshStatus,
     RefreshAfterConnect,
-    StatusUpdated(Result<StatusInfo, String>),
+    StatusUpdated(Result<StatusInfo, crate::device_error::DeviceError>),
     StreamControlMethodChanged(StreamControlMethod),
 
     // Templates
@@ -2524,7 +2526,7 @@ async fn execute_template_commands(
     Ok(())
 }
 
-async fn fetch_status(connection: Arc<Mutex<Rest>>) -> Result<StatusInfo, String> {
+async fn fetch_status(connection: Arc<Mutex<Rest>>) -> Result<StatusInfo, DeviceError> {
     // Use spawn_blocking to avoid runtime conflicts with ultimate64 crate
     // Wrap in timeout to prevent hangs when device is offline
     let result = tokio::time::timeout(
@@ -2534,7 +2536,9 @@ async fn fetch_status(connection: Arc<Mutex<Rest>>) -> Result<StatusInfo, String
 
             let device_info = match conn.info() {
                 Ok(info) => Some(format!("{} ({})", info.product, info.firmware_version)),
-                Err(e) => return Err(format!("Failed to get device info: {}", e)),
+                // The ultimate64 crate surfaces HTTP failures as strings; classify
+                // a 403 so the UI can say "wrong password" instead of "offline".
+                Err(e) => return Err(classify_crate_error(&e.to_string())),
             };
 
             let mounted_disks = match conn.drive_list() {
@@ -2556,8 +2560,25 @@ async fn fetch_status(connection: Arc<Mutex<Rest>>) -> Result<StatusInfo, String
 
     match result {
         Ok(Ok(status)) => status,
-        Ok(Err(e)) => Err(format!("Task error: {}", e)),
-        Err(_) => Err("Connection timed out - device may be offline".to_string()),
+        Ok(Err(e)) => Err(DeviceError::Network(format!("task join error: {}", e))),
+        Err(_) => Err(DeviceError::Timeout),
+    }
+}
+
+/// Best-effort classification of an `ultimate64` crate error string into a
+/// [`DeviceError`] — the crate doesn't expose the HTTP status, so we sniff the
+/// message. Only the auth case needs to be exact (it changes UX); everything
+/// else falls through to `Network`.
+fn classify_crate_error(msg: &str) -> DeviceError {
+    let s = msg.to_lowercase();
+    if s.contains("403")
+        || s.contains("forbidden")
+        || s.contains("unauthorized")
+        || s.contains("password")
+    {
+        DeviceError::Unauthorized
+    } else {
+        DeviceError::Network(msg.to_string())
     }
 }
 

--- a/src/net_utils.rs
+++ b/src/net_utils.rs
@@ -67,3 +67,24 @@ pub fn with_password(
         _ => request,
     }
 }
+
+/// Send a device request and validate the HTTP status, classifying any failure
+/// as a [`DeviceError`]. This is the single choke point for device REST calls:
+/// transport errors become `Timeout`/`Network`, and non-2xx responses become
+/// `Unauthorized`/`NotFound`/`Http`. Callers keep building the request (URL,
+/// method, query, body) and attach the password via [`with_password`]; this
+/// only owns the send + status classification.
+pub async fn device_send(
+    request: reqwest::RequestBuilder,
+) -> Result<reqwest::Response, crate::device_error::DeviceError> {
+    use crate::device_error::DeviceError;
+    let resp = request
+        .send()
+        .await
+        .map_err(|e| DeviceError::from_reqwest(&e))?;
+    if resp.status().is_success() {
+        Ok(resp)
+    } else {
+        Err(DeviceError::from_status(resp.status().as_u16()))
+    }
+}

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -40,22 +40,29 @@ pub fn check_for_updates(current_version: &str) -> Task<VersionCheckMessage> {
     )
 }
 
-/// Find the download URL for the current platform from release assets
+/// Find the download URL for the current platform from release assets.
+///
+/// Each platform lists its accepted asset suffixes in priority order — the
+/// first match wins. macOS prefers the drag-install `.dmg` (notarization
+/// stapled, nicer download) and falls back to the `.zip` for older releases
+/// that only shipped a zip.
 fn find_platform_asset(assets: &[GitHubAsset]) -> Option<&str> {
-    let target = if cfg!(target_os = "windows") {
-        "Win.exe"
+    let targets: &[&str] = if cfg!(target_os = "windows") {
+        &["Win.exe"]
     } else if cfg!(target_os = "macos") {
-        "MacOS.zip"
+        &["MacOS.dmg", "MacOS.zip"]
     } else if cfg!(target_os = "linux") {
-        "Linux.AppImage"
+        &["Linux.AppImage"]
     } else {
         return None;
     };
 
-    assets
-        .iter()
-        .find(|a| a.name.ends_with(target))
-        .map(|a| a.browser_download_url.as_str())
+    targets.iter().find_map(|target| {
+        assets
+            .iter()
+            .find(|a| a.name.ends_with(target))
+            .map(|a| a.browser_download_url.as_str())
+    })
 }
 
 async fn check_github_release(current_version: &str) -> Result<Option<NewVersionInfo>, String> {
@@ -154,5 +161,29 @@ mod tests {
     fn test_find_platform_asset_empty() {
         let assets: Vec<GitHubAsset> = vec![];
         assert!(find_platform_asset(&assets).is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_macos_prefers_dmg_over_zip() {
+        let mk = |name: &str| GitHubAsset {
+            name: name.to_string(),
+            browser_download_url: format!("https://example.com/{}", name),
+        };
+        // Both present → DMG wins.
+        let both = vec![
+            mk("Ultimate64Manager-MacOS.zip"),
+            mk("Ultimate64Manager-0.4.6-MacOS.dmg"),
+        ];
+        assert_eq!(
+            find_platform_asset(&both),
+            Some("https://example.com/Ultimate64Manager-0.4.6-MacOS.dmg")
+        );
+        // Only zip (older release) → falls back to zip.
+        let zip_only = vec![mk("Ultimate64Manager-MacOS.zip")];
+        assert_eq!(
+            find_platform_asset(&zip_only),
+            Some("https://example.com/Ultimate64Manager-MacOS.zip")
+        );
     }
 }


### PR DESCRIPTION
Unifies the Ultimate64 device REST layer behind a typed error and a single send path.
