### PR TITLE
Rework the video stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5496,6 +5496,7 @@ name = "ultimate64-manager"
 version = "0.4.7"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "chrono",
  "cpal",
  "dirs",
@@ -5513,12 +5514,14 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
+ "socket2 0.5.10",
  "suppaftp",
  "tokio",
  "ultimate64",
  "url",
  "urlencoding",
  "walkdir",
+ "wgpu",
  "winapi",
  "windows 0.62.2",
  "winres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,14 @@ authors = ["Marcin Spoczynski"]
 license = "MIT"
 
 [dependencies]
-iced = { version = "0.14.0", features = ["tokio", "image", "canvas", "advanced"] }
+iced = { version = "0.14.0", features = ["tokio", "image", "canvas", "advanced", "wgpu"] }
+# Custom VIC video shader widget renders through iced's wgpu backend; pin wgpu to
+# the same version iced 0.14 uses so our Pipeline/Primitive types match.
+wgpu = "27"
+bytemuck = { version = "1", features = ["derive"] }
+# Enlarge the UDP receive buffer for the VIC video stream (SO_RCVBUF) to avoid
+# packet drops during multi-packet frame bursts.
+socket2 = "0.5"
 tokio = { version = "1", features = ["full"] }
 ultimate64 = "0.5.5"
 anyhow = "1.0"

--- a/src/app/connection.rs
+++ b/src/app/connection.rs
@@ -34,6 +34,11 @@ impl Ultimate64Browser {
         };
         self.profile_manager.active_settings_mut().connection = conn_settings;
         self.settings = self.profile_manager.active_settings().clone();
+        // Persist the new host/password so the next launch's auto-connect uses it
+        // (otherwise the on-disk profile keeps the old address).
+        if let Err(e) = self.profile_manager.save() {
+            log::error!("Failed to save profiles: {}", e);
+        }
 
         self.establish_connection();
         // Trigger status refresh and remote browser refresh after a short delay

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,7 @@ mod styles;
 mod tab;
 mod templates;
 mod version_check;
+mod vic_shader;
 mod video_scaling;
 
 use assembly64_browser::{Assembly64Browser, Assembly64BrowserMessage};
@@ -190,6 +191,17 @@ pub fn main() -> iced::Result {
         // environment variables at this point.
         unsafe {
             std::env::set_var("WGPU_BACKEND", "gl");
+        }
+    }
+
+    // Force strict vsync (Fifo) for the video stream. iced's AutoVsync default can
+    // resolve to FifoRelaxed (adaptive vsync), which tears and judders whenever a
+    // frame misses the refresh deadline — very visible on the ~50 fps VIC stream.
+    // Strict Fifo gives clean, tear-free pacing. Users can still override.
+    if std::env::var_os("ICED_PRESENT_MODE").is_none() {
+        // SAFETY: startup, before any threads or the GPU backend initialize.
+        unsafe {
+            std::env::set_var("ICED_PRESENT_MODE", "fifo");
         }
     }
 
@@ -724,6 +736,14 @@ impl Ultimate64Browser {
         // Create file browser with configured starting directory
         let left_browser = FileBrowser::new(settings.default_paths.file_browser_start_dir.clone());
 
+        // QA hook: preload the video test pattern so the renderer can be verified
+        // without a device when U64_AUTO_TEST_PATTERN is set.
+        let mut video_streaming = VideoStreaming::new();
+        video_streaming.use_gpu_shader = settings.preferences.use_gpu_video_shader;
+        if std::env::var("U64_AUTO_TEST_PATTERN").is_ok() {
+            video_streaming.preload_test_pattern();
+        }
+
         // Load window icon
         let icon = load_window_icon();
 
@@ -740,11 +760,16 @@ impl Ultimate64Browser {
 
         let mut app = Self {
             // Restore the tab the user closed in last session, or fall back
-            // to the file browser for first-time launches.
-            active_tab: settings
-                .preferences
-                .last_active_tab
-                .unwrap_or(Tab::DualPaneBrowser),
+            // to the file browser for first-time launches. The QA hook forces the
+            // video tab so the renderer can be verified without a device.
+            active_tab: if std::env::var("U64_AUTO_TEST_PATTERN").is_ok() {
+                Tab::VideoViewer
+            } else {
+                settings
+                    .preferences
+                    .last_active_tab
+                    .unwrap_or(Tab::DualPaneBrowser)
+            },
             left_browser,
             remote_browser: RemoteBrowser::new(),
             active_pane: Pane::Left,
@@ -772,7 +797,7 @@ impl Ultimate64Browser {
             },
             consecutive_status_failures: 0,
             user_message: None,
-            video_streaming: VideoStreaming::new(),
+            video_streaming,
             assembly64_browser: Assembly64Browser::new(),
             basic_editor: BasicEditor::new(),
             pending_drop: None,
@@ -1518,6 +1543,13 @@ impl Ultimate64Browser {
 
                 self.video_streaming
                     .set_api_password(self.settings.connection.password.clone());
+                // Persist the video renderer choice when it changes.
+                if let StreamingMessage::GpuShaderToggled(on) = msg {
+                    self.settings.preferences.use_gpu_video_shader = on;
+                    if let Err(e) = self.settings.save() {
+                        log::warn!("Failed to save renderer preference: {}", e);
+                    }
+                }
                 // Handle screenshot result for user message
                 if let StreamingMessage::OpenInSeparateWindow = msg {
                     return Task::perform(async {}, |_| Message::OpenStreamingWindow);

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,7 @@ mod templates;
 mod version_check;
 mod vic_shader;
 mod video_scaling;
+mod virtual_keyboard;
 
 use assembly64_browser::{Assembly64Browser, Assembly64BrowserMessage};
 use basic_editor::{BasicEditor, BasicEditorMessage};

--- a/src/profile_manager.rs
+++ b/src/profile_manager.rs
@@ -229,7 +229,7 @@ pub struct ProfileManager {
     tags_input: String,
 
     // Streaming frame buffer reference for screenshot capture
-    streaming_frame: Option<Arc<std::sync::Mutex<Option<crate::streaming::ScaledFrame>>>>,
+    streaming_frame: Option<Arc<std::sync::Mutex<Option<crate::streaming::NativeFrame>>>>,
     // Captured screenshot PNG bytes (held in memory until profile is saved)
     pending_screenshot: Option<Vec<u8>>,
 
@@ -342,7 +342,7 @@ impl ProfileManager {
     /// Set the streaming frame buffer reference (called from main on each update).
     pub fn set_streaming_frame(
         &mut self,
-        frame: Arc<std::sync::Mutex<Option<crate::streaming::ScaledFrame>>>,
+        frame: Arc<std::sync::Mutex<Option<crate::streaming::NativeFrame>>>,
     ) {
         self.streaming_frame = Some(frame);
     }
@@ -1592,15 +1592,15 @@ impl ProfileManager {
                         {
                             let encoder = png::Encoder::new(
                                 std::io::Cursor::new(&mut png_bytes),
-                                frame.width,
-                                frame.height,
+                                crate::streaming::VIC_WIDTH,
+                                crate::streaming::VIC_HEIGHT,
                             );
                             let mut encoder = encoder;
                             encoder.set_color(png::ColorType::Rgba);
                             encoder.set_depth(png::BitDepth::Eight);
                             match encoder.write_header() {
                                 Ok(mut writer) => {
-                                    if let Err(e) = writer.write_image_data(&frame.data) {
+                                    if let Err(e) = writer.write_image_data(&frame.data[..]) {
                                         self.error_message =
                                             Some(format!("PNG encode failed: {}", e));
                                         return Task::none();

--- a/src/screenshot_api.rs
+++ b/src/screenshot_api.rs
@@ -325,7 +325,7 @@ fn smart_read(api: &U64Api, addr: u16, length: usize) -> Result<Vec<u8>, String>
 /// Returns 2 KB of the standard C64 uppercase/graphics character set.
 /// Used when the program points VIC at the built-in character ROM
 /// ($D000-$DFFF as seen through VIC bank 0 / bank 2).
-fn embedded_char_rom() -> Vec<u8> {
+pub(crate) fn embedded_char_rom() -> Vec<u8> {
     // Patterns for chars 0-127 (uppercase/graphics set).
     // Each entry is (char_code, [8 bytes]).
     #[rustfmt::skip]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -79,6 +79,15 @@ pub struct Preferences {
     /// don't have this field) loading cleanly.
     #[serde(default)]
     pub last_active_tab: Option<crate::Tab>,
+    /// Render the video stream via the GPU shader (true) or the compatibility
+    /// image path (false). Defaults on; users on a no-GPU / tiny-skia fallback
+    /// can turn it off.
+    #[serde(default = "default_true")]
+    pub use_gpu_video_shader: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_font_size() -> u32 {
@@ -111,6 +120,7 @@ impl Default for AppSettings {
                 default_song_duration: 180, // 3 minutes
                 font_size: 12,
                 last_active_tab: None,
+                use_gpu_video_shader: true,
             },
         }
     }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -4,8 +4,8 @@ use iced::{
     event::{self, Event},
     keyboard::{self, Key, Modifiers},
     widget::{
-        button, checkbox, column, container, image as iced_image, mouse_area, row, rule,
-        scrollable, text, text_input, tooltip, Column, Space,
+        button, checkbox, column, container, image as iced_image, mouse_area, responsive, row,
+        rule, scrollable, text, text_input, tooltip, Column, Space,
     },
     Element, Length, Subscription, Task,
 };
@@ -13,9 +13,7 @@ use iced::{
 use crate::net_utils::get_local_ip;
 use crate::settings::StreamControlMethod;
 use crate::stream_control::{send_stop_command, send_stream_command};
-use crate::video_scaling::{
-    apply_crt_effect, apply_scanlines, integer_scale, scale2x, C64_PALETTE,
-};
+use crate::video_scaling::C64_PALETTE;
 
 use crate::remote_device::RemoteDevice;
 use std::collections::VecDeque;
@@ -88,13 +86,14 @@ impl std::fmt::Display for StreamMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ScaleMode {
+    /// Pixel-perfect integer scaling: the frame is shown at the largest whole
+    /// multiple that fits, centered, with a letterbox border. No pixel effect.
     #[default]
-    Int2x, // Integer 2x scale (sharp pixels)
-    Int3x, // Integer 3x scale
-
+    PixelPerfect,
     Scale2x,   // EPX/Scale2x smoothing
     Scanlines, // CRT scanline effect
-    CRT,       // Shadow mask + scanlines
+    CRT,       // Shadow mask + scanlines + curvature
+    Glow,      // Phosphor bloom — bright pixels bleed light (GPU shader only)
 }
 
 #[derive(Debug, Clone)]
@@ -110,6 +109,12 @@ pub enum StreamingMessage {
     CommandSent(Result<String, String>),
     StreamModeChanged(StreamMode),
     ScaleModeChanged(ScaleMode),
+    /// Switch between the GPU shader renderer (true) and the compatibility image
+    /// renderer (false).
+    GpuShaderToggled(bool),
+    /// Load a static test pattern so the renderer/scaling/effects can be verified
+    /// without a live device.
+    LoadTestPattern,
     PortChanged(String),
     AudioToggled(bool),
     ToggleFullscreen,
@@ -190,41 +195,192 @@ impl AudioBufferState {
     }
 }
 impl ScaleMode {
-    fn to_u8(self) -> u8 {
+    /// Stable numeric id shared cross-thread via `scale_mode_shared` and used as
+    /// the fragment shader's effect selector.
+    pub fn to_u8(self) -> u8 {
         match self {
-            ScaleMode::Int2x => 0,
-            ScaleMode::Int3x => 1,
-            ScaleMode::Scale2x => 2,
-            ScaleMode::Scanlines => 3,
-            ScaleMode::CRT => 4,
+            ScaleMode::PixelPerfect => 0,
+            ScaleMode::Scale2x => 1,
+            ScaleMode::Scanlines => 2,
+            ScaleMode::CRT => 3,
+            ScaleMode::Glow => 4,
         }
     }
 
     fn from_u8(v: u8) -> Self {
         match v {
-            0 => ScaleMode::Int2x,
-            1 => ScaleMode::Int3x,
-            2 => ScaleMode::Scale2x,
-            3 => ScaleMode::Scanlines,
-            4 => ScaleMode::CRT,
-            _ => ScaleMode::Int2x,
+            0 => ScaleMode::PixelPerfect,
+            1 => ScaleMode::Scale2x,
+            2 => ScaleMode::Scanlines,
+            3 => ScaleMode::CRT,
+            4 => ScaleMode::Glow,
+            _ => ScaleMode::PixelPerfect,
         }
     }
 }
 
-/// Combined frame data and dimensions - must be updated atomically to prevent display corruption
+/// A static `VIC_WIDTH`×`VIC_HEIGHT` RGBA test pattern: 16 vertical C64 color
+/// bars over the top, a horizontal luminance ramp below, and a 1px white grid so
+/// integer scaling and the effects can be eyeballed without a live device.
+fn test_pattern_rgba() -> Vec<u8> {
+    let (w, h) = (VIC_WIDTH as usize, VIC_HEIGHT as usize);
+    let mut buf = vec![0u8; w * h * 4];
+    let bar_w = w / 16;
+    let split = h / 2;
+    for y in 0..h {
+        for x in 0..w {
+            let (r, g, b) = if y < split {
+                let c = C64_PALETTE[(x / bar_w).min(15)];
+                (c[0], c[1], c[2])
+            } else {
+                let v = (x * 255 / (w - 1)) as u8;
+                (v, v, v)
+            };
+            // 1px grid every 16 source pixels.
+            let grid = x % 16 == 0 || y % 16 == 0;
+            let idx = (y * w + x) * 4;
+            if grid {
+                buf[idx..idx + 4].copy_from_slice(&[255, 255, 255, 255]);
+            } else {
+                buf[idx..idx + 4].copy_from_slice(&[r, g, b, 255]);
+            }
+        }
+    }
+    buf
+}
+
+/// Apply a scale mode's pixel effect to a native frame, returning the RGBA bytes
+/// and their dimensions. PixelPerfect is a passthrough (the GPU nearest-scales the
+/// native frame); the effect modes run their CPU kernel to bake a 2× buffer. Used
+/// by the compatibility render path and by screenshots — never per rendered frame
+/// on the shader path.
+fn render_effect(native: &[u8], mode: ScaleMode) -> (Vec<u8>, u32, u32) {
+    use crate::video_scaling::{apply_crt_effect, apply_scanlines, scale2x};
+    match mode {
+        // Glow is a GPU-shader-only effect; the compatibility path shows plain.
+        ScaleMode::PixelPerfect | ScaleMode::Glow => (native.to_vec(), VIC_WIDTH, VIC_HEIGHT),
+        ScaleMode::Scale2x => (
+            scale2x(native, VIC_WIDTH, VIC_HEIGHT),
+            VIC_WIDTH * 2,
+            VIC_HEIGHT * 2,
+        ),
+        ScaleMode::Scanlines => (
+            apply_scanlines(native, VIC_WIDTH, VIC_HEIGHT),
+            VIC_WIDTH * 2,
+            VIC_HEIGHT * 2,
+        ),
+        ScaleMode::CRT => (
+            apply_crt_effect(native, VIC_WIDTH, VIC_HEIGHT),
+            VIC_WIDTH * 2,
+            VIC_HEIGHT * 2,
+        ),
+    }
+}
+
+/// Build an image `Handle` for the compatibility (non-shader) render path. Only
+/// called once per changed frame, never in `view()`.
+fn build_compat_handle(native: &[u8], mode: ScaleMode) -> iced::widget::image::Handle {
+    let (data, w, h) = render_effect(native, mode);
+    iced::widget::image::Handle::from_rgba(w, h, data)
+}
+
+/// Pixel-perfect integer-fit display of `handle` (compatibility path): pick the
+/// largest whole multiple of the handle's native size that fits the available
+/// space, render at exactly that size with nearest sampling, centered with a
+/// letterbox border. `native` is the handle's own pixel size.
+fn vic_image_responsive<'a>(
+    handle: iced::widget::image::Handle,
+    native: (u32, u32),
+) -> Element<'a, StreamingMessage> {
+    let (nw, nh) = (native.0 as f32, native.1 as f32);
+    responsive(move |size| {
+        let scale = (size.width / nw)
+            .floor()
+            .min((size.height / nh).floor())
+            .max(1.0);
+        container(
+            iced_image(handle.clone())
+                .width(nw * scale)
+                .height(nh * scale)
+                .filter_method(FilterMethod::Nearest),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .center_x(Length::Fill)
+        .center_y(Length::Fill)
+        .into()
+    })
+    .into()
+}
+
+/// "Waiting for frames" placeholder shared by the video views.
+fn waiting_placeholder<'a>(size: u32) -> Element<'a, StreamingMessage> {
+    text("Waiting for frames...")
+        .size(size as f32)
+        .color(iced::Color::WHITE)
+        .into()
+}
+
+/// A uniform-width Video-Scale mode button (fills its cell so the buttons align
+/// in a tidy grid), highlighted when it's the active mode.
+fn mode_button(
+    selected: ScaleMode,
+    mode: ScaleMode,
+    label: &'static str,
+    tip: &'static str,
+    fs: &crate::styles::FontSizes,
+) -> Element<'static, StreamingMessage> {
+    tooltip(
+        button(text(label).size(fs.tiny))
+            .on_press(StreamingMessage::ScaleModeChanged(mode))
+            .padding([4, 6])
+            .width(Length::Fill)
+            .style(if selected == mode {
+                button::primary
+            } else {
+                button::secondary
+            }),
+        text(tip).size(fs.small),
+        tooltip::Position::Bottom,
+    )
+    .style(container::bordered_box)
+    .into()
+}
+
+/// Native dimensions of the handle `build_compat_handle` produces for `mode`.
+fn compat_handle_dimensions(mode: ScaleMode) -> (u32, u32) {
+    match mode {
+        ScaleMode::PixelPerfect | ScaleMode::Glow => (VIC_WIDTH, VIC_HEIGHT),
+        _ => (VIC_WIDTH * 2, VIC_HEIGHT * 2),
+    }
+}
+
+/// One assembled VIC frame at native resolution (always `VIC_WIDTH`×`VIC_HEIGHT`).
+///
+/// Scaling and pixel effects are applied on the GPU at render time (shader path)
+/// or lazily at display/screenshot time (compatibility path) — never per-frame on
+/// the stream thread. `version` increases on every stored frame so the renderer
+/// can skip redundant work / GPU uploads when the frame hasn't changed. `data` is
+/// `Arc`-wrapped so both the display and the shader program share it without
+/// copying the ~417 KB buffer.
 #[derive(Clone)]
-pub struct ScaledFrame {
-    pub data: Vec<u8>,
-    pub width: u32,
-    pub height: u32,
+pub struct NativeFrame {
+    pub data: Arc<Vec<u8>>,
+    pub version: u64,
 }
 
 pub struct VideoStreaming {
     pub is_streaming: bool,
-    pub frame_buffer: Arc<Mutex<Option<ScaledFrame>>>, // Scaled RGBA + dimensions for display
-    pub current_handle: Option<iced::widget::image::Handle>, // Cached image handle for display
-    pub current_dimensions: (u32, u32),                // Dimensions of current handle
+    pub frame_buffer: Arc<Mutex<Option<NativeFrame>>>, // Native RGBA, produced by the stream thread
+    pub current_handle: Option<iced::widget::image::Handle>, // Compatibility-path image handle
+    /// Latest native frame + its version, sampled from `frame_buffer` in
+    /// `FrameUpdate`. The shader program reads these directly.
+    pub current_frame: Option<Arc<Vec<u8>>>,
+    pub current_version: u64,
+    /// When true, render via the wgpu shader widget; when false, use the
+    /// compatibility responsive-image path (works on the tiny-skia fallback).
+    pub use_gpu_shader: bool,
+    pub current_dimensions: (u32, u32), // Dimensions of current handle
     pub stop_signal: Arc<AtomicBool>,
     stream_handle: Option<thread::JoinHandle<()>>, // Video receive thread
     audio_stream_handle: Option<thread::JoinHandle<()>>, // Audio playback thread
@@ -247,7 +403,6 @@ pub struct VideoStreaming {
     pub ultimate_host: Option<String>,
     // API password for REST API fallback
     pub api_password: Option<String>,
-    scale_mode_shared: Arc<std::sync::atomic::AtomicU8>, // For thread to read
     pub stream_control_method: StreamControlMethod, // Stream control method for communicating with Ultimate64
 }
 
@@ -263,7 +418,13 @@ impl VideoStreaming {
             is_streaming: false,
             frame_buffer: Arc::new(Mutex::new(None)),
             current_handle: None,
-            current_dimensions: (VIC_WIDTH * 2, VIC_HEIGHT * 2),
+            current_frame: None,
+            current_version: 0,
+            // GPU shader path by default; the Compatibility toggle switches to the
+            // image path for machines on iced's tiny-skia fallback. Overridden
+            // from persisted settings at startup.
+            use_gpu_shader: true,
+            current_dimensions: (VIC_WIDTH, VIC_HEIGHT),
             stop_signal: Arc::new(AtomicBool::new(false)),
             stream_handle: None,
             audio_stream_handle: None,
@@ -271,7 +432,7 @@ impl VideoStreaming {
             command_input: String::new(),
             command_history: Vec::new(),
             stream_mode: StreamMode::Unicast,
-            scale_mode: ScaleMode::Int2x,
+            scale_mode: ScaleMode::PixelPerfect,
             listen_port: "11000".to_string(),
             packets_received: Arc::new(Mutex::new(0)),
             audio_packets_received: Arc::new(Mutex::new(0)),
@@ -283,7 +444,6 @@ impl VideoStreaming {
             last_key_time: None,
             ultimate_host: None,
             api_password: None,
-            scale_mode_shared: Arc::new(std::sync::atomic::AtomicU8::new(0)),
             stream_control_method: StreamControlMethod::default(),
         }
     }
@@ -302,6 +462,20 @@ impl VideoStreaming {
     pub fn set_stream_control_method(&mut self, method: StreamControlMethod) {
         self.stream_control_method = method;
     }
+
+    /// Preload the static test pattern (QA hook — lets the video path render
+    /// without a device, e.g. when `U64_AUTO_TEST_PATTERN` is set at launch).
+    pub fn preload_test_pattern(&mut self) {
+        let pattern = Arc::new(test_pattern_rgba());
+        self.current_version = self.current_version.wrapping_add(1);
+        self.current_frame = Some(pattern);
+        if !self.use_gpu_shader {
+            if let Some(frame) = &self.current_frame {
+                self.current_handle = Some(build_compat_handle(frame, self.scale_mode));
+                self.current_dimensions = compat_handle_dimensions(self.scale_mode);
+            }
+        }
+    }
     pub fn update_impl(
         &mut self,
         message: StreamingMessage,
@@ -317,23 +491,29 @@ impl VideoStreaming {
                 Task::none()
             }
             StreamingMessage::FrameUpdate => {
-                // Create the image Handle here, only once per frame update
-                // This avoids creating new Handles on every view() call
-                if let Ok(fb) = self.frame_buffer.lock() {
-                    if let Some(frame) = &*fb {
-                        self.current_handle = Some(iced::widget::image::Handle::from_rgba(
-                            frame.width,
-                            frame.height,
-                            frame.data.clone(),
-                        ));
-                        self.current_dimensions = (frame.width, frame.height);
+                // Sample the latest native frame once per tick (not per view()).
+                // Skip everything if the frame hasn't changed since last tick.
+                let latest = self.frame_buffer.lock().ok().and_then(|fb| fb.clone());
+                if let Some(frame) = latest {
+                    if frame.version != self.current_version {
+                        self.current_version = frame.version;
+                        self.current_frame = Some(frame.data.clone()); // Arc clone (cheap)
+                                                                       // The compatibility (image-widget) path needs a Handle;
+                                                                       // the shader path reads `current_frame` directly. Effects
+                                                                       // in compatibility mode are applied here, off the hot path.
+                        if !self.use_gpu_shader {
+                            self.current_handle =
+                                Some(build_compat_handle(&frame.data, self.scale_mode));
+                            self.current_dimensions = compat_handle_dimensions(self.scale_mode);
+                        }
                     }
                 }
                 Task::none()
             }
             StreamingMessage::TakeScreenshot => {
                 if self.is_streaming {
-                    // Fast path: grab the current frame directly from the stream buffer.
+                    // Fast path: grab the latest native frame from the stream buffer
+                    // and bake the current effect into it once, at capture time.
                     let frame_data = if let Ok(fb_guard) = self.frame_buffer.lock() {
                         fb_guard.clone()
                     } else {
@@ -341,8 +521,9 @@ impl VideoStreaming {
                     };
 
                     if let Some(frame) = frame_data {
+                        let (data, w, h) = render_effect(&frame.data, self.scale_mode);
                         Task::perform(
-                            save_screenshot_to_pictures(frame.data, frame.width, frame.height),
+                            save_screenshot_to_pictures(data, w, h),
                             StreamingMessage::ScreenshotComplete,
                         )
                     } else {
@@ -408,8 +589,39 @@ impl VideoStreaming {
             }
             StreamingMessage::ScaleModeChanged(mode) => {
                 self.scale_mode = mode;
-                self.scale_mode_shared
-                    .store(mode.to_u8(), Ordering::Relaxed);
+                // Rebuild the compatibility handle immediately so a mode switch is
+                // visible without waiting for the next frame (shader path reads the
+                // mode live in view()).
+                if !self.use_gpu_shader {
+                    if let Some(frame) = &self.current_frame {
+                        self.current_handle = Some(build_compat_handle(frame, mode));
+                        self.current_dimensions = compat_handle_dimensions(mode);
+                    }
+                }
+                Task::none()
+            }
+            StreamingMessage::GpuShaderToggled(on) => {
+                self.use_gpu_shader = on;
+                // Switching to the compatibility path needs a handle built from the
+                // current frame right away.
+                if !on {
+                    if let Some(frame) = &self.current_frame {
+                        self.current_handle = Some(build_compat_handle(frame, self.scale_mode));
+                        self.current_dimensions = compat_handle_dimensions(self.scale_mode);
+                    }
+                }
+                Task::none()
+            }
+            StreamingMessage::LoadTestPattern => {
+                let pattern = Arc::new(test_pattern_rgba());
+                self.current_version = self.current_version.wrapping_add(1);
+                self.current_frame = Some(pattern);
+                if !self.use_gpu_shader {
+                    if let Some(frame) = &self.current_frame {
+                        self.current_handle = Some(build_compat_handle(frame, self.scale_mode));
+                        self.current_dimensions = compat_handle_dimensions(self.scale_mode);
+                    }
+                }
                 Task::none()
             }
             StreamingMessage::PortChanged(port) => {
@@ -651,40 +863,52 @@ impl VideoStreaming {
         }
     }
 
+    /// The live video display element — GPU shader path or compatibility image
+    /// path — wrapped in a `mouse_area` for click-to-toggle-fullscreen. Shared by
+    /// all three views. Shows a "waiting" placeholder until the first frame lands.
+    fn video_element(&self, placeholder_size: u32) -> Element<'_, StreamingMessage> {
+        let inner: Element<'_, StreamingMessage> = if self.use_gpu_shader {
+            match &self.current_frame {
+                Some(frame) => crate::vic_shader::vic_video(
+                    frame.clone(),
+                    self.current_version,
+                    self.scale_mode,
+                ),
+                None => waiting_placeholder(placeholder_size),
+            }
+        } else {
+            match &self.current_handle {
+                // PixelPerfect gets crisp integer-fit; effect modes keep the
+                // fill/contain path (their output is already a baked 2× buffer).
+                Some(handle) if self.scale_mode == ScaleMode::PixelPerfect => {
+                    vic_image_responsive(handle.clone(), self.current_dimensions)
+                }
+                Some(handle) => iced_image(handle.clone())
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .content_fit(iced::ContentFit::Contain)
+                    .filter_method(FilterMethod::Nearest)
+                    .into(),
+                None => waiting_placeholder(placeholder_size),
+            }
+        };
+        mouse_area(inner)
+            .on_press(StreamingMessage::VideoClicked)
+            .into()
+    }
+
     /// Fullscreen view - video fills the entire available space with black letterboxing
     pub fn view_fullscreen(&self, font_size: u32) -> Element<'_, StreamingMessage> {
         let fs = crate::styles::FontSizes::from_base(font_size);
-        let video_content: Element<'_, StreamingMessage> = if self.is_streaming {
-            // Use cached handle - created once in FrameUpdate, not on every view()
-            if let Some(ref handle) = self.current_handle {
-                // In fullscreen, fill the screen and let ContentFit::Contain handle aspect ratio
-                let video_image = mouse_area(
-                    iced_image(handle.clone())
-                        .width(Length::Fill)
-                        .height(Length::Fill)
-                        .content_fit(iced::ContentFit::Contain)
-                        .filter_method(FilterMethod::Nearest),
-                )
-                .on_press(StreamingMessage::VideoClicked);
-
-                container(video_image)
-                    .width(Length::Fill)
-                    .height(Length::Fill)
-                    .center_x(Length::Fill)
-                    .center_y(Length::Fill)
-                    .into()
+        let video_content: Element<'_, StreamingMessage> =
+            if self.is_streaming || self.current_frame.is_some() {
+                self.video_element(fs.header + 2)
             } else {
-                text("Waiting for frames...")
+                text("Stream not active - press ESC to exit")
                     .size(fs.header + 2)
                     .color(iced::Color::WHITE)
                     .into()
-            }
-        } else {
-            text("Stream not active - press ESC to exit")
-                .size(fs.header + 2)
-                .color(iced::Color::WHITE)
-                .into()
-        };
+            };
 
         // Exit hint at the top with keyboard toggle
         let keyboard_btn = button(
@@ -738,36 +962,15 @@ impl VideoStreaming {
     /// Separate window view - similar to fullscreen but for dedicated streaming window
     pub fn view_separate_window(&self, font_size: u32) -> Element<'_, StreamingMessage> {
         let fs = crate::styles::FontSizes::from_base(font_size);
-        let video_content: Element<'_, StreamingMessage> = if self.is_streaming {
-            // Use cached handle - created once in FrameUpdate, not on every view()
-            if let Some(ref handle) = self.current_handle {
-                let video_image = mouse_area(
-                    iced_image(handle.clone())
-                        .width(Length::Fill)
-                        .height(Length::Fill)
-                        .content_fit(iced::ContentFit::Contain)
-                        .filter_method(FilterMethod::Nearest),
-                )
-                .on_press(StreamingMessage::VideoClicked);
-
-                container(video_image)
-                    .width(Length::Fill)
-                    .height(Length::Fill)
-                    .center_x(Length::Fill)
-                    .center_y(Length::Fill)
-                    .into()
+        let video_content: Element<'_, StreamingMessage> =
+            if self.is_streaming || self.current_frame.is_some() {
+                self.video_element(fs.header + 2)
             } else {
-                text("Waiting for frames...")
+                text("Stream not active")
                     .size(fs.header + 2)
                     .color(iced::Color::WHITE)
                     .into()
-            }
-        } else {
-            text("Stream not active")
-                .size(fs.header + 2)
-                .color(iced::Color::WHITE)
-                .into()
-        };
+            };
 
         // Controls at the top with keyboard toggle
         let keyboard_btn = button(
@@ -821,28 +1024,18 @@ impl VideoStreaming {
         let audio_packets = self.audio_packets_received.lock().map(|p| *p).unwrap_or(0);
 
         // === LEFT SIDE: Video display (fluid scaling) ===
-        let video_display: Element<'_, StreamingMessage> = if self.is_streaming {
-            // Use cached handle - created once in FrameUpdate, not on every view()
-            if let Some(ref handle) = self.current_handle {
-                let video_image = mouse_area(
-                    iced_image(handle.clone())
-                        .width(Length::Fill)
-                        .height(Length::Fill)
-                        .content_fit(iced::ContentFit::Contain)
-                        .filter_method(FilterMethod::Nearest),
-                )
-                .on_press(StreamingMessage::VideoClicked);
-
+        let video_display: Element<'_, StreamingMessage> =
+            if self.is_streaming || self.current_frame.is_some() {
                 let scale_label = match self.scale_mode {
-                    ScaleMode::Int2x => "2x",
-                    ScaleMode::Int3x => "3x",
+                    ScaleMode::PixelPerfect => "Pixel Perfect",
                     ScaleMode::Scale2x => "Smooth",
                     ScaleMode::Scanlines => "Scanlines",
                     ScaleMode::CRT => "CRT",
+                    ScaleMode::Glow => "Glow",
                 };
 
                 column![
-                    container(video_image)
+                    container(self.video_element(fs.large))
                         .width(Length::Fill)
                         .height(Length::Fill)
                         .center_x(Length::Fill)
@@ -859,87 +1052,31 @@ impl VideoStreaming {
                 .height(Length::Fill)
                 .into()
             } else {
-                // Image not decoded yet, show raw frame info
-                if let Ok(frame_guard) = self.frame_buffer.lock() {
-                    if let Some(frame) = &*frame_guard {
-                        container(
-                            column![
-                                text("RECEIVING FRAMES").size(fs.large + 2),
-                                text(format!(
-                                    "{} bytes ({}x{})",
-                                    frame.data.len(),
-                                    frame.width,
-                                    frame.height
-                                ))
-                                .size(fs.normal),
-                                text(format!(
-                                    "Video: {} | Audio: {}",
-                                    video_packets, audio_packets
-                                ))
-                                .size(fs.normal),
-                            ]
-                            .spacing(5)
-                            .align_x(iced::Alignment::Center),
-                        )
-                        .width(Length::Fill)
-                        .height(Length::Fill)
-                        .center_x(Length::Fill)
-                        .center_y(Length::Fill)
-                        .into()
-                    } else {
-                        container(
-                            column![
-                                text("Waiting for frames...").size(fs.large),
-                                text(format!(
-                                    "Video: {} | Audio: {}",
-                                    video_packets, audio_packets
-                                ))
-                                .size(fs.normal),
-                            ]
-                            .spacing(5)
-                            .align_x(iced::Alignment::Center),
-                        )
-                        .width(Length::Fill)
-                        .height(Length::Fill)
-                        .center_x(Length::Fill)
-                        .center_y(Length::Fill)
-                        .into()
+                let status_info = match self.stream_mode {
+                    StreamMode::Unicast => {
+                        format!("Unicast mode: Will send to Ultimate64 at port 64 to start stream",)
                     }
-                } else {
-                    container(text("Waiting for frames...").size(fs.large))
-                        .width(Length::Fill)
-                        .height(Length::Fill)
-                        .center_x(Length::Fill)
-                        .center_y(Length::Fill)
-                        .into()
-                }
-            }
-        } else {
-            let status_info = match self.stream_mode {
-                StreamMode::Unicast => {
-                    format!("Unicast mode: Will send to Ultimate64 at port 64 to start stream",)
-                }
-                StreamMode::Multicast => {
-                    "Multicast mode: 239.0.1.64 (requires wired LAN)".to_string()
-                }
-            };
+                    StreamMode::Multicast => {
+                        "Multicast mode: 239.0.1.64 (requires wired LAN)".to_string()
+                    }
+                };
 
-            container(
-                column![
-                    text("VIDEO STREAM INACTIVE").size(fs.large + 2),
-                    Space::new().height(10),
-                    text(status_info.clone()).size(fs.small),
-                    Space::new().height(5),
-                    text("Click START to begin streaming").size(fs.small),
-                ]
-                .align_x(iced::Alignment::Center),
-            )
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .center_x(Length::Fill)
-            .center_y(Length::Fill)
-            .into()
-        };
+                container(
+                    column![
+                        text("VIDEO STREAM INACTIVE").size(fs.large + 2),
+                        Space::new().height(10),
+                        text(status_info.clone()).size(fs.small),
+                        Space::new().height(5),
+                        text("Click START to begin streaming").size(fs.small),
+                    ]
+                    .align_x(iced::Alignment::Center),
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .center_x(Length::Fill)
+                .center_y(Length::Fill)
+                .into()
+            };
 
         // === RIGHT SIDE: Controls panel ===
 
@@ -993,91 +1130,91 @@ impl VideoStreaming {
         ]
         .spacing(5);
 
-        // Scale mode selection
+        // Scale mode selection — uniform-width buttons in a tidy 2-2-1 grid.
+        let sm = self.scale_mode;
         let scale_section = column![
             text("Video Scale").size(fs.normal),
             row![
-                tooltip(
-                    button(text("2x").size(fs.tiny))
-                        .on_press(StreamingMessage::ScaleModeChanged(ScaleMode::Int2x))
-                        .padding([4, 6])
-                        .style(if self.scale_mode == ScaleMode::Int2x {
-                            button::primary
-                        } else {
-                            button::secondary
-                        }),
-                    "Integer 2x (sharp pixels)",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
-                tooltip(
-                    button(text("3x").size(fs.tiny))
-                        .on_press(StreamingMessage::ScaleModeChanged(ScaleMode::Int3x))
-                        .padding([4, 6])
-                        .style(if self.scale_mode == ScaleMode::Int3x {
-                            button::primary
-                        } else {
-                            button::secondary
-                        }),
-                    "Integer 3x (sharp pixels)",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
-                tooltip(
-                    button(text("Smooth").size(fs.tiny))
-                        .on_press(StreamingMessage::ScaleModeChanged(ScaleMode::Scale2x))
-                        .padding([4, 6])
-                        .style(if self.scale_mode == ScaleMode::Scale2x {
-                            button::primary
-                        } else {
-                            button::secondary
-                        }),
+                mode_button(
+                    sm,
+                    ScaleMode::PixelPerfect,
+                    "Pixel Perfect",
+                    "Sharp integer scaling (largest whole multiple that fits)",
+                    &fs,
+                ),
+                mode_button(
+                    sm,
+                    ScaleMode::Scale2x,
+                    "Smooth",
                     "Scale2x edge smoothing",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
+                    &fs
+                ),
             ]
-            .spacing(3),
+            .spacing(4),
             row![
-                tooltip(
-                    button(text("Scanlines").size(fs.tiny))
-                        .on_press(StreamingMessage::ScaleModeChanged(ScaleMode::Scanlines))
-                        .padding([4, 6])
-                        .style(if self.scale_mode == ScaleMode::Scanlines {
-                            button::primary
-                        } else {
-                            button::secondary
-                        }),
-                    "CRT scanlines",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
-                tooltip(
-                    button(text("CRT").size(fs.tiny))
-                        .on_press(StreamingMessage::ScaleModeChanged(ScaleMode::CRT))
-                        .padding([4, 6])
-                        .style(if self.scale_mode == ScaleMode::CRT {
-                            button::primary
-                        } else {
-                            button::secondary
-                        }),
-                    "CRT shadow mask + scanlines",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
+                mode_button(
+                    sm,
+                    ScaleMode::Scanlines,
+                    "Scanlines",
+                    "Soft CRT scanlines",
+                    &fs,
+                ),
+                mode_button(
+                    sm,
+                    ScaleMode::CRT,
+                    "CRT",
+                    "CRT: curvature + shadow mask + scanlines",
+                    &fs,
+                ),
             ]
-            .spacing(3),
+            .spacing(4),
+            mode_button(
+                sm,
+                ScaleMode::Glow,
+                "Glow",
+                "Phosphor bloom on a curved CRT (GPU renderer only)",
+                &fs,
+            ),
+            tooltip(
+                row![
+                    checkbox(self.use_gpu_shader)
+                        .on_toggle(StreamingMessage::GpuShaderToggled)
+                        .size(fs.small as f32),
+                    text("GPU renderer").size(fs.small),
+                ]
+                .spacing(5)
+                .align_y(iced::Alignment::Center),
+                text(
+                    "GPU shader (crisp, fast). Uncheck for the compatibility renderer \
+                     if video doesn't appear (no-GPU / tiny-skia fallback)."
+                )
+                .size(fs.small),
+                tooltip::Position::Bottom,
+            )
+            .style(container::bordered_box),
+            tooltip(
+                button(text("Test Pattern").size(fs.tiny))
+                    .on_press(StreamingMessage::LoadTestPattern)
+                    .padding([4, 6])
+                    .width(Length::Fill)
+                    .style(button::secondary),
+                text("Show a static test pattern to verify the renderer without a device")
+                    .size(fs.small),
+                tooltip::Position::Bottom,
+            )
+            .style(container::bordered_box),
         ]
-        .spacing(5); // Stream controls with keyboard toggle
+        .spacing(6); // Stream controls with keyboard toggle
                      // Screenshot works when streaming (instant frame grab) OR when connected
                      // without streaming (REST API capture via screenshot_api module).
         let screenshot_button = {
-            let can_screenshot = self.is_streaming || self.ultimate_host.is_some();
+            // Only allow capture while streaming (instant frame grab). The REST
+            // no-stream path is disabled — it was half-baked.
             let btn = button(text("📸").size(fs.small)).padding([6, 10]);
-            if can_screenshot {
+            if self.is_streaming {
                 btn.on_press(StreamingMessage::TakeScreenshot)
             } else {
-                btn
+                btn.style(button::secondary)
             }
         };
 
@@ -1149,7 +1286,7 @@ impl VideoStreaming {
                     if self.is_streaming {
                         "Capture frame to Pictures folder"
                     } else {
-                        "Capture frame to Pictures folder"
+                        "Start streaming to capture a frame"
                     },
                     tooltip::Position::Bottom,
                 )
@@ -1250,10 +1387,14 @@ impl VideoStreaming {
     pub fn subscription(&self) -> Subscription<StreamingMessage> {
         let mut subscriptions = Vec::new();
 
-        // Frame update subscription (~25 fps)
+        // Sample the latest frame on a fixed timer that ticks a bit faster than
+        // the source (~50/60 fps) so no frame is skipped. A timer actively forces
+        // a redraw each tick; window::frames() only reports redraws iced already
+        // decided to do, which under-drove the display rate. FrameUpdate is a cheap
+        // no-op when the frame version is unchanged.
         if self.is_streaming {
             subscriptions.push(
-                iced::time::every(Duration::from_millis(40)).map(|_| StreamingMessage::FrameUpdate),
+                iced::time::every(Duration::from_millis(12)).map(|_| StreamingMessage::FrameUpdate),
             );
         }
 
@@ -1289,11 +1430,6 @@ impl VideoStreaming {
         let frame_buffer = self.frame_buffer.clone();
         let stop_signal = self.stop_signal.clone();
         let packets_counter = self.packets_received.clone();
-        let scale_mode_shared = self.scale_mode_shared.clone();
-
-        // Sync current scale mode to shared atomic
-        self.scale_mode_shared
-            .store(self.scale_mode.to_u8(), Ordering::Relaxed);
 
         log::info!("Starting video stream... mode={:?}, port={}", mode, port);
         self.stop_signal.store(false, Ordering::Relaxed);
@@ -1336,6 +1472,22 @@ impl VideoStreaming {
         if let Err(e) = socket.set_nonblocking(true) {
             log::error!("Failed to set non-blocking: {}", e);
             return;
+        }
+
+        // Enlarge the kernel receive buffer so bursts of a frame's packets aren't
+        // dropped (each VIC frame is many UDP packets at ~50 fps). The OS may clamp
+        // the request; that's fine — we still get more than the small default.
+        {
+            let sock_ref = socket2::SockRef::from(&socket);
+            let want = 4 * 1024 * 1024; // 4 MB
+            match sock_ref.set_recv_buffer_size(want) {
+                Ok(()) => log::info!(
+                    "UDP recv buffer: requested {} B, got {:?} B",
+                    want,
+                    sock_ref.recv_buffer_size()
+                ),
+                Err(e) => log::warn!("Could not enlarge UDP recv buffer: {}", e),
+            }
         }
 
         // 2. Small delay to ensure socket is fully ready
@@ -1396,6 +1548,7 @@ impl VideoStreaming {
             let rgba_size = (VIC_WIDTH * VIC_HEIGHT * 4) as usize;
             let mut rgba_frame: Vec<u8> = vec![0u8; rgba_size];
             let mut first_packet = true;
+            let mut frame_version: u64 = 0;
 
             // Build color lookup table
             let mut color_lut: Vec<[u8; 8]> = Vec::with_capacity(256);
@@ -1471,47 +1624,18 @@ impl VideoStreaming {
                             }
                         }
 
-                        // Frame complete - apply scaling and store
+                        // Frame complete — publish the native frame. Scaling and
+                        // effects happen at render time (GPU shader) or lazily in
+                        // the compatibility path, never here on the stream thread.
                         if is_frame_end {
-                            // Clone the frame BEFORE scaling - this prevents new packets
-                            // from corrupting the frame while we're scaling it
-                            let frame_snapshot = rgba_frame.clone();
-
-                            // Get current scale mode and apply scaling to the snapshot
-                            let current_mode =
-                                ScaleMode::from_u8(scale_mode_shared.load(Ordering::Relaxed));
-
-                            let (scaled, dims) = match current_mode {
-                                ScaleMode::Int2x => (
-                                    integer_scale(&frame_snapshot, VIC_WIDTH, VIC_HEIGHT, 2),
-                                    (VIC_WIDTH * 2, VIC_HEIGHT * 2),
-                                ),
-                                ScaleMode::Int3x => (
-                                    // Capped to 2x: true 3x scaling strobes on larger textures.
-                                    integer_scale(&frame_snapshot, VIC_WIDTH, VIC_HEIGHT, 2),
-                                    (VIC_WIDTH * 2, VIC_HEIGHT * 2),
-                                ),
-                                ScaleMode::Scale2x => (
-                                    scale2x(&frame_snapshot, VIC_WIDTH, VIC_HEIGHT),
-                                    (VIC_WIDTH * 2, VIC_HEIGHT * 2),
-                                ),
-                                ScaleMode::Scanlines => (
-                                    apply_scanlines(&frame_snapshot, VIC_WIDTH, VIC_HEIGHT),
-                                    (VIC_WIDTH * 2, VIC_HEIGHT * 2),
-                                ),
-                                ScaleMode::CRT => (
-                                    apply_crt_effect(&frame_snapshot, VIC_WIDTH, VIC_HEIGHT),
-                                    (VIC_WIDTH * 2, VIC_HEIGHT * 2),
-                                ),
-                            };
-
-                            // Store scaled frame with dimensions atomically
-                            // This prevents display corruption from dimension/data mismatch
+                            frame_version = frame_version.wrapping_add(1);
+                            // One copy out of the reused assembly buffer, wrapped in
+                            // an Arc the display and shader share without recopying.
+                            let snapshot = Arc::new(rgba_frame.clone());
                             if let Ok(mut fb) = frame_buffer.lock() {
-                                *fb = Some(ScaledFrame {
-                                    data: scaled,
-                                    width: dims.0,
-                                    height: dims.1,
+                                *fb = Some(NativeFrame {
+                                    data: snapshot,
+                                    version: frame_version,
                                 });
                             }
                         }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -5,7 +5,7 @@ use iced::{
     keyboard::{self, Key, Modifiers},
     widget::{
         button, checkbox, column, container, image as iced_image, mouse_area, responsive, row,
-        rule, scrollable, text, text_input, tooltip, Column, Space,
+        rule, stack, text, text_input, tooltip, Space,
     },
     Element, Length, Subscription, Task,
 };
@@ -128,6 +128,10 @@ pub enum StreamingMessage {
     UltimateHostChanged(String), // Set the host for stream control
     // Separate window support
     OpenInSeparateWindow, // Open streaming in a separate window
+    // Virtual PETSCII keyboard
+    ToggleVirtualKeyboard,
+    VkSend(u8),     // inject one PETSCII byte
+    VkModifier(u8), // toggle SHIFT / C= / CTRL (see virtual_keyboard::MOD_*)
 }
 
 /// Simple linear resampler for converting Ultimate64's ~47983 Hz to 48000 Hz
@@ -321,6 +325,67 @@ fn waiting_placeholder<'a>(size: u32) -> Element<'a, StreamingMessage> {
         .into()
 }
 
+/// Inject one PETSCII byte into the device's KERNAL keyboard buffer: clear
+/// LSTX/NDX ($C5/$C6), write the byte to the buffer head ($0277), set NDX=1 so
+/// the KERNAL processes it. Only needs a live connection (no streaming required).
+/// Shared by the physical-key capture and the virtual keyboard.
+fn send_petscii(
+    connection: Option<Arc<Mutex<dyn RemoteDevice>>>,
+    code: u8,
+) -> Task<StreamingMessage> {
+    let Some(conn) = connection else {
+        return Task::none();
+    };
+    Task::perform(
+        async move {
+            let result = tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                tokio::task::spawn_blocking(move || {
+                    let c = conn.lock().unwrap();
+                    c.write_mem(0x00C5, &[0, 0])
+                        .map_err(|e| format!("Clear failed: {}", e))?;
+                    c.write_mem(0x0277, &[code])
+                        .map_err(|e| format!("Buffer write failed: {}", e))?;
+                    c.write_mem(0x00C6, &[1])
+                        .map_err(|e| format!("Count write failed: {}", e))?;
+                    Ok(())
+                }),
+            )
+            .await;
+            match result {
+                Ok(Ok(r)) => r,
+                Ok(Err(e)) => Err(format!("Task error: {}", e)),
+                Err(_) => Err("Keyboard write timed out".to_string()),
+            }
+        },
+        StreamingMessage::KeySent,
+    )
+}
+
+/// One icon button for the video overlay bar. `msg = None` renders it disabled.
+/// `active` highlights the button (e.g. audio/keyboard enabled).
+fn overlay_button(
+    glyph: &'static str,
+    msg: Option<StreamingMessage>,
+    active: bool,
+    tip: &'static str,
+    fs: &crate::styles::FontSizes,
+) -> Element<'static, StreamingMessage> {
+    let mut btn = button(text(glyph).size(fs.normal).color(iced::Color::WHITE))
+        .padding([4, 8])
+        .style(if active {
+            button::primary
+        } else {
+            button::text
+        });
+    if let Some(m) = msg {
+        btn = btn.on_press(m);
+    }
+    tooltip(btn, text(tip).size(fs.small), tooltip::Position::Top)
+        .style(container::bordered_box)
+        .into()
+}
+
 /// A uniform-width Video-Scale mode button (fills its cell so the buttons align
 /// in a tidy grid), highlighted when it's the active mode.
 fn mode_button(
@@ -398,7 +463,13 @@ pub struct VideoStreaming {
     last_click_time: Option<std::time::Instant>, // For double-click detection
     // Keyboard control
     pub keyboard_enabled: bool, // Whether keyboard capture is active
-    last_key_time: Option<std::time::Instant>, // Rate limiting for keyboard
+    // Virtual on-screen PETSCII keyboard
+    show_virtual_keyboard: bool,
+    vk_shift: bool,
+    vk_comm: bool,
+    vk_ctrl: bool,
+    vk_glyphs: Vec<iced::widget::image::Handle>, // char-ROM glyphs, built on first show
+    last_key_time: Option<std::time::Instant>,   // Rate limiting for keyboard
     // Ultimate64 host for stream control (binary protocol on port 64)
     pub ultimate_host: Option<String>,
     // API password for REST API fallback
@@ -441,6 +512,11 @@ impl VideoStreaming {
             is_fullscreen: false,
             last_click_time: None,
             keyboard_enabled: false,
+            show_virtual_keyboard: false,
+            vk_shift: false,
+            vk_comm: false,
+            vk_ctrl: false,
+            vk_glyphs: Vec::new(),
             last_key_time: None,
             ultimate_host: None,
             api_password: None,
@@ -789,48 +865,9 @@ impl VideoStreaming {
 
                 if let Some(code) = petscii {
                     log::debug!("KEYBOARD: {:?} -> PETSCII {} (0x{:02X})", key, code, code);
-
-                    if let Some(conn) = connection {
-                        return Task::perform(
-                            async move {
-                                // Use timeout to prevent hangs
-                                let result = tokio::time::timeout(
-                                    std::time::Duration::from_millis(500),
-                                    tokio::task::spawn_blocking(move || {
-                                        let c = conn.lock().unwrap();
-
-                                        // Match type_text behavior from ultimate64 library:
-                                        // 1. Clear LSTX ($C5) and NDX ($C6) - last key and buffer count
-                                        c.write_mem(0x00C5, &[0, 0])
-                                            .map_err(|e| format!("Clear failed: {}", e))?;
-
-                                        // 2. Write PETSCII code to keyboard buffer at $0277
-                                        c.write_mem(0x0277, &[code])
-                                            .map_err(|e| format!("Buffer write failed: {}", e))?;
-
-                                        // 3. Set buffer count to 1 at $C6 to trigger processing
-                                        c.write_mem(0x00C6, &[1])
-                                            .map_err(|e| format!("Count write failed: {}", e))?;
-
-                                        Ok(())
-                                    }),
-                                )
-                                .await;
-
-                                match result {
-                                    Ok(Ok(r)) => r,
-                                    Ok(Err(e)) => Err(format!("Task error: {}", e)),
-                                    Err(_) => Err("Keyboard write timed out".to_string()),
-                                }
-                            },
-                            StreamingMessage::KeySent,
-                        );
-                    } else {
-                        log::warn!("KEYBOARD: No connection available!");
-                    }
-                } else {
-                    log::trace!("KEYBOARD: Key {:?} not mapped", key);
+                    return send_petscii(connection, code);
                 }
+                log::trace!("KEYBOARD: Key {:?} not mapped", key);
                 Task::none()
             }
 
@@ -859,6 +896,32 @@ impl VideoStreaming {
             StreamingMessage::OpenInSeparateWindow => {
                 // Handled by main.rs which manages window creation
                 Task::none()
+            }
+
+            StreamingMessage::ToggleVirtualKeyboard => {
+                self.show_virtual_keyboard = !self.show_virtual_keyboard;
+                // Build the glyph atlas once, on first show.
+                if self.show_virtual_keyboard && self.vk_glyphs.is_empty() {
+                    self.vk_glyphs = crate::virtual_keyboard::build_glyphs();
+                }
+                Task::none()
+            }
+            StreamingMessage::VkModifier(id) => {
+                match id {
+                    crate::virtual_keyboard::MOD_SHIFT => self.vk_shift = !self.vk_shift,
+                    crate::virtual_keyboard::MOD_COMMODORE => self.vk_comm = !self.vk_comm,
+                    _ => self.vk_ctrl = !self.vk_ctrl,
+                }
+                Task::none()
+            }
+            StreamingMessage::VkSend(code) => {
+                // One-shot modifiers: applied to this key, then released — much
+                // less confusing than a latched SHIFT that turns everything into
+                // graphics.
+                self.vk_shift = false;
+                self.vk_comm = false;
+                self.vk_ctrl = false;
+                send_petscii(connection, code)
             }
         }
     }
@@ -894,6 +957,104 @@ impl VideoStreaming {
         };
         mouse_area(inner)
             .on_press(StreamingMessage::VideoClicked)
+            .into()
+    }
+
+    /// Media-player style control bar overlaid on the bottom of the video:
+    /// play/stop, screenshot, fullscreen, pop-out, audio, keyboard.
+    fn video_overlay_bar(&self, fs: &crate::styles::FontSizes) -> Element<'_, StreamingMessage> {
+        let live_stop = if self.is_streaming {
+            overlay_button(
+                "■",
+                Some(StreamingMessage::StopStream),
+                false,
+                "Stop stream",
+                fs,
+            )
+        } else {
+            overlay_button(
+                "▶",
+                Some(StreamingMessage::StartStream),
+                false,
+                "Start stream",
+                fs,
+            )
+        };
+        let shot = overlay_button(
+            "📸",
+            self.is_streaming
+                .then_some(StreamingMessage::TakeScreenshot),
+            false,
+            if self.is_streaming {
+                "Capture frame to Pictures"
+            } else {
+                "Start streaming to capture"
+            },
+            fs,
+        );
+        let full = overlay_button(
+            "⛶",
+            Some(StreamingMessage::ToggleFullscreen),
+            self.is_fullscreen,
+            "Fullscreen",
+            fs,
+        );
+        let popout = overlay_button(
+            "⧉",
+            Some(StreamingMessage::OpenInSeparateWindow),
+            false,
+            "Open in a separate window",
+            fs,
+        );
+        let audio = overlay_button(
+            "🔊",
+            Some(StreamingMessage::AudioToggled(!self.audio_enabled)),
+            self.audio_enabled,
+            "Toggle audio",
+            fs,
+        );
+        let keyboard = overlay_button(
+            "⌨",
+            self.is_streaming
+                .then_some(StreamingMessage::ToggleKeyboard(!self.keyboard_enabled)),
+            self.keyboard_enabled,
+            "Capture the PC keyboard (type into the C64 while streaming)",
+            fs,
+        );
+        let vkbd = overlay_button(
+            "🎹",
+            Some(StreamingMessage::ToggleVirtualKeyboard),
+            self.show_virtual_keyboard,
+            "Show/hide the on-screen PETSCII keyboard",
+            fs,
+        );
+
+        let bar = row![
+            live_stop,
+            shot,
+            full,
+            popout,
+            Space::new().width(Length::Fill),
+            vkbd,
+            audio,
+            keyboard,
+        ]
+        .spacing(6)
+        .align_y(iced::Alignment::Center);
+
+        container(bar)
+            .width(Length::Fill)
+            .padding([6, 10])
+            .style(|_theme| container::Style {
+                background: Some(iced::Background::Color(iced::Color::from_rgba(
+                    0.0, 0.0, 0.0, 0.55,
+                ))),
+                border: iced::Border {
+                    radius: 8.0.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
             .into()
     }
 
@@ -1019,121 +1180,106 @@ impl VideoStreaming {
 
     pub fn view(&self, font_size: u32) -> Element<'_, StreamingMessage> {
         let fs = crate::styles::FontSizes::from_base(font_size);
-        // Video packets info
-        let video_packets = self.packets_received.lock().map(|p| *p).unwrap_or(0);
-        let audio_packets = self.audio_packets_received.lock().map(|p| *p).unwrap_or(0);
 
         // === LEFT SIDE: Video display (fluid scaling) ===
-        let video_display: Element<'_, StreamingMessage> =
-            if self.is_streaming || self.current_frame.is_some() {
-                let scale_label = match self.scale_mode {
-                    ScaleMode::PixelPerfect => "Pixel Perfect",
-                    ScaleMode::Scale2x => "Smooth",
-                    ScaleMode::Scanlines => "Scanlines",
-                    ScaleMode::CRT => "CRT",
-                    ScaleMode::Glow => "Glow",
-                };
-
-                column![
-                    container(self.video_element(fs.large))
-                        .width(Length::Fill)
-                        .height(Length::Fill)
-                        .center_x(Length::Fill)
-                        .center_y(Length::Fill),
-                    text(format!(
-                        "{}x{} [{}] | Video: {} | Audio: {} | Double-click for fullscreen",
-                        VIC_WIDTH, VIC_HEIGHT, scale_label, video_packets, audio_packets
-                    ))
-                    .size(fs.tiny),
-                ]
-                .spacing(5)
-                .align_x(iced::Alignment::Center)
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .into()
-            } else {
-                let status_info = match self.stream_mode {
-                    StreamMode::Unicast => {
-                        format!("Unicast mode: Will send to Ultimate64 at port 64 to start stream",)
-                    }
-                    StreamMode::Multicast => {
-                        "Multicast mode: 239.0.1.64 (requires wired LAN)".to_string()
-                    }
-                };
-
-                container(
-                    column![
-                        text("VIDEO STREAM INACTIVE").size(fs.large + 2),
-                        Space::new().height(10),
-                        text(status_info.clone()).size(fs.small),
-                        Space::new().height(5),
-                        text("Click START to begin streaming").size(fs.small),
-                    ]
-                    .align_x(iced::Alignment::Center),
-                )
+        // Base video content (the picture, or the inactive message).
+        let video_base: Element<'_, StreamingMessage> = if self.is_streaming
+            || self.current_frame.is_some()
+        {
+            container(self.video_element(fs.large))
                 .width(Length::Fill)
                 .height(Length::Fill)
                 .center_x(Length::Fill)
                 .center_y(Length::Fill)
                 .into()
+        } else {
+            let status_info = match self.stream_mode {
+                StreamMode::Unicast => {
+                    "Unicast: the device streams here once you press ▶".to_string()
+                }
+                StreamMode::Multicast => "Multicast 239.0.1.64 (requires wired LAN)".to_string(),
             };
+            container(
+                column![
+                    text("VIDEO STREAM INACTIVE").size(fs.large + 2),
+                    Space::new().height(10),
+                    text(status_info).size(fs.small),
+                    Space::new().height(5),
+                    text("Press ▶ below to begin streaming").size(fs.small),
+                ]
+                .align_x(iced::Alignment::Center),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x(Length::Fill)
+            .center_y(Length::Fill)
+            .into()
+        };
+
+        // Bottom overlay stack on the video: the on-screen keyboard (if shown)
+        // sits just above the media-player control bar, both floating on the video.
+        let mut overlay_col = column![].spacing(6).align_x(iced::Alignment::Center);
+        if self.show_virtual_keyboard {
+            overlay_col = overlay_col.push(crate::virtual_keyboard::view(
+                &self.vk_glyphs,
+                self.vk_shift,
+                self.vk_comm,
+                self.vk_ctrl,
+                &fs,
+            ));
+        }
+        overlay_col = overlay_col.push(self.video_overlay_bar(&fs));
+
+        let video_display: Element<'_, StreamingMessage> = stack![
+            video_base,
+            container(overlay_col)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .align_x(iced::alignment::Horizontal::Center)
+                .align_y(iced::alignment::Vertical::Bottom)
+                .padding(8),
+        ]
+        .into();
 
         // === RIGHT SIDE: Controls panel ===
+        let dim = iced::Color::from_rgb(0.55, 0.57, 0.62);
 
-        // Mode selection
+        let source_button = |label: &'static str, mode: StreamMode| {
+            button(text(label).size(fs.small))
+                .on_press(StreamingMessage::StreamModeChanged(mode))
+                .padding([4, 8])
+                .width(Length::Fill)
+                .style(if self.stream_mode == mode {
+                    button::primary
+                } else {
+                    button::secondary
+                })
+        };
+
+        // SOURCE — stream mode + port
         let mode_section = column![
-            text("Stream Mode").size(fs.normal),
+            text("SOURCE").size(fs.small).color(dim),
             row![
-                tooltip(
-                    button(text("Unicast").size(fs.small))
-                        .on_press(StreamingMessage::StreamModeChanged(StreamMode::Unicast))
-                        .padding([4, 8])
-                        .style(if self.stream_mode == StreamMode::Unicast {
-                            button::primary
-                        } else {
-                            button::secondary
-                        }),
-                    "Direct UDP connection (requires Ethernet, WiFi not supported)",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
-                tooltip(
-                    button(text("Multicast").size(fs.small))
-                        .on_press(StreamingMessage::StreamModeChanged(StreamMode::Multicast))
-                        .padding([4, 8])
-                        .style(if self.stream_mode == StreamMode::Multicast {
-                            button::primary
-                        } else {
-                            button::secondary
-                        }),
-                    "Multicast 239.0.1.64 (requires wired LAN)",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
+                source_button("Unicast", StreamMode::Unicast),
+                source_button("Multicast", StreamMode::Multicast),
             ]
-            .spacing(5),
-            Space::new().height(5),
+            .spacing(4),
             row![
-                text("Port:").size(fs.small),
-                tooltip(
-                    text_input("11000", &self.listen_port)
-                        .on_input(StreamingMessage::PortChanged)
-                        .width(Length::Fixed(70.0))
-                        .size(fs.small),
-                    "Video port (audio uses port+1)",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
+                text("Port").size(fs.small).color(dim),
+                text_input("11000", &self.listen_port)
+                    .on_input(StreamingMessage::PortChanged)
+                    .width(Length::Fill)
+                    .size(fs.small),
             ]
-            .spacing(5)
+            .spacing(6)
             .align_y(iced::Alignment::Center),
         ]
-        .spacing(5);
+        .spacing(6);
 
         // Scale mode selection — uniform-width buttons in a tidy 2-2-1 grid.
         let sm = self.scale_mode;
         let scale_section = column![
-            text("Video Scale").size(fs.normal),
+            text("DISPLAY").size(fs.small).color(dim),
             row![
                 mode_button(
                     sm,
@@ -1204,160 +1350,14 @@ impl VideoStreaming {
             )
             .style(container::bordered_box),
         ]
-        .spacing(6); // Stream controls with keyboard toggle
-                     // Screenshot works when streaming (instant frame grab) OR when connected
-                     // without streaming (REST API capture via screenshot_api module).
-        let screenshot_button = {
-            // Only allow capture while streaming (instant frame grab). The REST
-            // no-stream path is disabled — it was half-baked.
-            let btn = button(text("📸").size(fs.small)).padding([6, 10]);
-            if self.is_streaming {
-                btn.on_press(StreamingMessage::TakeScreenshot)
-            } else {
-                btn.style(button::secondary)
-            }
-        };
+        .spacing(6);
 
-        // Keyboard toggle button
-        let keyboard_button = if self.is_streaming {
-            tooltip(
-                button(
-                    text(if self.keyboard_enabled {
-                        "⌨️ Enabled"
-                    } else {
-                        "⌨️ Disabled"
-                    })
-                    .size(fs.small),
-                )
-                .on_press(StreamingMessage::ToggleKeyboard(!self.keyboard_enabled))
-                .padding([6, 10])
-                .style(if self.keyboard_enabled {
-                    button::primary
-                } else {
-                    button::secondary
-                }),
-                "Enable keyboard input to C64 (type in video window)",
-                tooltip::Position::Bottom,
-            )
-            .style(container::bordered_box)
-        } else {
-            tooltip(
-                button(text("⌨ Disabled").size(fs.small)).padding([6, 10]),
-                "Start streaming first",
-                tooltip::Position::Bottom,
-            )
-            .style(container::bordered_box)
-        };
-
-        // Separate window button
-        let separate_window_button = tooltip(
-            button(text("⧉").size(fs.small))
-                .on_press(StreamingMessage::OpenInSeparateWindow)
-                .padding([6, 10]),
-            "Open video in separate window",
-            tooltip::Position::Bottom,
-        )
-        .style(container::bordered_box);
-
-        let stream_controls = column![
-            text("Stream Control").size(fs.normal),
-            row![
-                if self.is_streaming {
-                    tooltip(
-                        button(text("■ STOP").size(fs.small))
-                            .on_press(StreamingMessage::StopStream)
-                            .padding([6, 14]),
-                        "Stop video stream",
-                        tooltip::Position::Bottom,
-                    )
-                    .style(container::bordered_box)
-                } else {
-                    tooltip(
-                        button(text("▶ LIVE").size(fs.small))
-                            .on_press(StreamingMessage::StartStream)
-                            .padding([6, 14]),
-                        "Start video stream",
-                        tooltip::Position::Bottom,
-                    )
-                    .style(container::bordered_box)
-                },
-                tooltip(
-                    screenshot_button,
-                    if self.is_streaming {
-                        "Capture frame to Pictures folder"
-                    } else {
-                        "Start streaming to capture a frame"
-                    },
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
-                separate_window_button,
-            ]
-            .spacing(5)
-            .align_y(iced::Alignment::Center),
-            row![
-                tooltip(
-                    checkbox(self.audio_enabled)
-                        .label("🔊 Audio")
-                        .on_toggle(StreamingMessage::AudioToggled)
-                        .size(16)
-                        .text_size(fs.small),
-                    "Enable audio streaming (port+1)",
-                    tooltip::Position::Bottom,
-                )
-                .style(container::bordered_box),
-                keyboard_button,
-            ]
-            .spacing(10)
-            .align_y(iced::Alignment::Center),
-        ]
-        .spacing(5)
-        .align_x(iced::Alignment::Center);
-
-        // Command prompt section
-        let command_history_items: Vec<Element<'_, StreamingMessage>> = self
-            .command_history
-            .iter()
-            .rev()
-            .take(10)
-            .map(|cmd| text(cmd).size(fs.tiny).into())
-            .collect();
-
-        let command_section = column![
-            text("COMMAND PROMPT").size(fs.normal),
-            row![
-                text("C64>").size(fs.small),
-                text_input("Enter BASIC command...", &self.command_input)
-                    .on_input(StreamingMessage::CommandInputChanged)
-                    .on_submit(StreamingMessage::SendCommand)
-                    .width(Length::Fill)
-                    .size(fs.small),
-            ]
-            .spacing(5)
-            .align_y(iced::Alignment::Center),
-            button(text("Send").size(fs.small))
-                .on_press(StreamingMessage::SendCommand)
-                .padding([4, 12])
-                .width(Length::Fill),
-            scrollable(Column::with_children(command_history_items).spacing(2))
-                .height(Length::Fill),
-        ]
-        .spacing(5);
-
-        // Right panel with all controls
+        // Right panel — SOURCE + DISPLAY (the console now lives in the bottom bar).
         let right_panel = container(
-            column![
-                mode_section,
-                rule::horizontal(1),
-                scale_section,
-                rule::horizontal(1),
-                stream_controls,
-                rule::horizontal(1),
-                command_section,
-            ]
-            .spacing(10)
-            .padding(10)
-            .width(Length::Fixed(220.0)),
+            column![mode_section, rule::horizontal(1), scale_section,]
+                .spacing(12)
+                .padding(10)
+                .width(Length::Fixed(210.0)),
         )
         .height(Length::Fill);
 
@@ -1374,10 +1374,27 @@ impl VideoStreaming {
         .spacing(10)
         .height(Length::Fill);
 
+        // On-screen PETSCII keyboard (toggled from the overlay 🎹 button).
+        // Command console, moved to a full-width bar at the bottom.
+        let console_bar = row![
+            text("C64>").size(fs.small).color(dim),
+            text_input("Enter BASIC command…", &self.command_input)
+                .on_input(StreamingMessage::CommandInputChanged)
+                .on_submit(StreamingMessage::SendCommand)
+                .width(Length::Fill)
+                .size(fs.small),
+            button(text("Send").size(fs.small))
+                .on_press(StreamingMessage::SendCommand)
+                .padding([4, 14]),
+        ]
+        .spacing(8)
+        .align_y(iced::Alignment::Center);
+
         column![
             text("VIC VIDEO STREAM").size(fs.header + 2),
             rule::horizontal(1),
             main_content,
+            console_bar,
         ]
         .spacing(10)
         .height(Length::Fill)

--- a/src/vic_shader.rs
+++ b/src/vic_shader.rs
@@ -1,0 +1,489 @@
+//! GPU video path — a custom iced `shader` widget that renders the native VIC
+//! frame through a persistent wgpu texture.
+//!
+//! The stream thread publishes native 384×272 RGBA frames; this widget uploads
+//! the latest frame to a **persistent** GPU texture (only when it changed) and
+//! draws a single integer-fit quad, sampling nearest. Scaling is pixel-perfect
+//! (largest whole multiple that fits, centered, letterboxed) and the Scale2x /
+//! Scanlines / CRT effects run in the fragment shader — so no per-frame CPU
+//! scaling, buffer clones, or texture re-allocation happen at all.
+//!
+//! Requires iced's wgpu backend (enabled by default). On the tiny-skia fallback
+//! this widget can't render; the streaming views fall back to the compatibility
+//! image path instead (see `VideoStreaming::use_gpu_shader`).
+
+use std::sync::Arc;
+
+use iced::widget::shader::{Pipeline, Primitive, Program, Viewport};
+use iced::{Element, Length, Rectangle};
+
+use crate::streaming::{ScaleMode, StreamingMessage};
+
+/// Native VIC frame size — must match `streaming::VIC_WIDTH/VIC_HEIGHT`.
+const TEX_W: u32 = crate::streaming::VIC_WIDTH;
+const TEX_H: u32 = crate::streaming::VIC_HEIGHT;
+
+/// The video display element backed by the wgpu shader widget.
+pub fn vic_video<'a>(
+    frame: Arc<Vec<u8>>,
+    version: u64,
+    mode: ScaleMode,
+) -> Element<'a, StreamingMessage> {
+    iced::widget::shader(VicProgram {
+        frame,
+        version,
+        effect: mode.to_u8() as u32,
+    })
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .into()
+}
+
+// ─── Program ────────────────────────────────────────────────────────────────
+
+struct VicProgram {
+    frame: Arc<Vec<u8>>,
+    version: u64,
+    effect: u32,
+}
+
+impl Program<StreamingMessage> for VicProgram {
+    type State = ();
+    type Primitive = VicPrimitive;
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        _cursor: iced::mouse::Cursor,
+        _bounds: Rectangle,
+    ) -> Self::Primitive {
+        VicPrimitive {
+            frame: self.frame.clone(),
+            version: self.version,
+            effect: self.effect,
+        }
+    }
+}
+
+// ─── Primitive ──────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct VicPrimitive {
+    frame: Arc<Vec<u8>>,
+    version: u64,
+    effect: u32,
+}
+
+impl Primitive for VicPrimitive {
+    type Pipeline = VicPipeline;
+
+    fn prepare(
+        &self,
+        pipeline: &mut Self::Pipeline,
+        _device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        bounds: &Rectangle,
+        viewport: &Viewport,
+    ) {
+        // Upload the frame only when it actually changed.
+        if self.version != pipeline.last_version {
+            pipeline.last_version = self.version;
+            queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &pipeline.texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &self.frame,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(TEX_W * 4),
+                    rows_per_image: Some(TEX_H),
+                },
+                wgpu::Extent3d {
+                    width: TEX_W,
+                    height: TEX_H,
+                    depth_or_array_layers: 1,
+                },
+            );
+        }
+
+        // Compute the pixel-perfect integer-fit quad in NDC. iced sets the render
+        // pass viewport to this widget's bounds for the `draw()` path, so NDC
+        // [-1,1] maps to the bounds — the quad is just a centered box whose half-
+        // extents are the integer-scaled size over the bounds size. Integer scale
+        // is computed in *physical* pixels so each source texel is a whole number
+        // of device pixels (crisp).
+        let sf = viewport.scale_factor() as f32;
+        let bw = bounds.width * sf;
+        let bh = bounds.height * sf;
+
+        let scale = (bw / TEX_W as f32)
+            .floor()
+            .min((bh / TEX_H as f32).floor())
+            .max(1.0);
+        let dw = TEX_W as f32 * scale;
+        let dh = TEX_H as f32 * scale;
+
+        let half_x = (dw / bw).min(1.0);
+        let half_y = (dh / bh).min(1.0);
+        // rect = (x0, y0_top, x1, y1_bottom)
+        let uniforms = Uniforms {
+            rect: [-half_x, half_y, half_x, -half_y],
+            out_size: [dw, dh],
+            effect: self.effect,
+            _pad: 0,
+        };
+        queue.write_buffer(&pipeline.uniform_buf, 0, bytemuck::bytes_of(&uniforms));
+    }
+
+    fn draw(&self, pipeline: &Self::Pipeline, render_pass: &mut wgpu::RenderPass<'_>) -> bool {
+        // Draw inside iced's existing render pass (viewport/scissor already set to
+        // our bounds). Reusing the pass avoids opening a second one, which on
+        // tile-based GPUs (Apple Silicon) would reload+store the whole framebuffer
+        // every frame — the main render cost at large window sizes.
+        render_pass.set_pipeline(&pipeline.pipeline);
+        render_pass.set_bind_group(0, &pipeline.bind_group, &[]);
+        render_pass.draw(0..6, 0..1);
+        true
+    }
+}
+
+// ─── Pipeline (persistent GPU state, created once) ──────────────────────────
+
+struct VicPipeline {
+    pipeline: wgpu::RenderPipeline,
+    texture: wgpu::Texture,
+    uniform_buf: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    last_version: u64,
+}
+
+impl Pipeline for VicPipeline {
+    fn new(device: &wgpu::Device, _queue: &wgpu::Queue, format: wgpu::TextureFormat) -> Self {
+        // Match the texture's sRGB-ness to the render target so colors round-trip
+        // unchanged. iced picks a *linear* (non-sRGB) surface format when gamma
+        // correction is on (its default) and encodes gamma in its own shaders. If
+        // we used an sRGB texture against a linear target, sampling would
+        // linearize the values but the target would never re-encode them, making
+        // the whole picture much darker. So: sRGB target → sRGB texture; linear
+        // target → linear (Unorm) texture, which passes the raw C64 palette bytes
+        // straight through (and makes the effects match the CPU kernels, which
+        // also operate in gamma space).
+        let tex_format = if format.is_srgb() {
+            wgpu::TextureFormat::Rgba8UnormSrgb
+        } else {
+            wgpu::TextureFormat::Rgba8Unorm
+        };
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("vic_shader texture"),
+            size: wgpu::Extent3d {
+                width: TEX_W,
+                height: TEX_H,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: tex_format,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("vic_shader sampler"),
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            ..Default::default()
+        });
+
+        let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("vic_shader uniforms"),
+            size: std::mem::size_of::<Uniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("vic_shader bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("vic_shader bg"),
+            layout: &bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: uniform_buf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("vic_shader wgsl"),
+            source: wgpu::ShaderSource::Wgsl(SHADER_WGSL.into()),
+        });
+
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("vic_shader layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("vic_shader pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            multiview: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            texture,
+            uniform_buf,
+            bind_group,
+            last_version: u64::MAX, // force first upload
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct Uniforms {
+    /// Quad in NDC: (x0, y0_top, x1, y1_bottom).
+    rect: [f32; 4],
+    /// Displayed quad size in physical pixels — lets the CRT shadow mask key off
+    /// the true output resolution.
+    out_size: [f32; 2],
+    /// 0 = pixel-perfect, 1 = Scale2x, 2 = Scanlines, 3 = CRT.
+    effect: u32,
+    _pad: u32,
+}
+
+const SHADER_WGSL: &str = r#"
+struct Uniforms {
+    rect: vec4<f32>,
+    out_size: vec2<f32>,
+    effect: u32,
+    _pad: u32,
+};
+
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+@group(0) @binding(2) var<uniform> u: Uniforms;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    // Two triangles over the rect. uv has y=0 at the top (matches frame row 0).
+    var corner = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0),
+        vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0), vec2<f32>(0.0, 1.0),
+    );
+    let c = corner[vi];
+    let ndc_x = mix(u.rect.x, u.rect.z, c.x);
+    let ndc_y = mix(u.rect.y, u.rect.w, c.y);
+    var out: VsOut;
+    out.pos = vec4<f32>(ndc_x, ndc_y, 0.0, 1.0);
+    out.uv = c;
+    return out;
+}
+
+fn eq(a: vec3<f32>, b: vec3<f32>) -> bool {
+    let d = abs(a - b);
+    return d.x < 0.02 && d.y < 0.02 && d.z < 0.02;
+}
+
+const TEX_SIZE: vec2<f32> = vec2<f32>(384.0, 272.0);
+
+// Scale2x / EPX, mirroring video_scaling::scale2x.
+fn epx(uv: vec2<f32>) -> vec3<f32> {
+    let texel = 1.0 / TEX_SIZE;
+    let p = textureSample(tex, samp, uv).rgb;
+    let a = textureSample(tex, samp, uv + vec2<f32>(0.0, -texel.y)).rgb; // top
+    let b = textureSample(tex, samp, uv + vec2<f32>(texel.x, 0.0)).rgb;  // right
+    let c = textureSample(tex, samp, uv + vec2<f32>(-texel.x, 0.0)).rgb; // left
+    let d = textureSample(tex, samp, uv + vec2<f32>(0.0, texel.y)).rgb;  // bottom
+    let f = fract(uv * TEX_SIZE);
+    var res = p;
+    if (f.x < 0.5 && f.y < 0.5) {
+        if (eq(a, c) && !eq(a, b) && !eq(c, d)) { res = a; }
+    } else if (f.x >= 0.5 && f.y < 0.5) {
+        if (eq(a, b) && !eq(a, c) && !eq(b, d)) { res = b; }
+    } else if (f.x < 0.5 && f.y >= 0.5) {
+        if (eq(c, d) && !eq(a, c) && !eq(b, d)) { res = c; }
+    } else {
+        if (eq(b, d) && !eq(a, b) && !eq(c, d)) { res = d; }
+    }
+    return res;
+}
+
+// Barrel distortion: bend x by y^2 and y by x^2 around the center.
+fn curve(uv0: vec2<f32>) -> vec2<f32> {
+    var c = uv0 * 2.0 - 1.0;
+    c = c + c * vec2<f32>(c.y * c.y, c.x * c.x) * vec2<f32>(0.03, 0.045);
+    return c * 0.5 + 0.5;
+}
+
+// The "tube" shading shared by CRT and Glow: per-scanline shading, an RGB shadow
+// mask keyed to the real output resolution, a soft vignette, and a brightness
+// boost to compensate for the darkening.
+fn tube(color_in: vec3<f32>, uv: vec2<f32>) -> vec3<f32> {
+    var color = color_in;
+
+    let line = fract(uv.y * TEX_SIZE.y);
+    color = color * mix(0.6, 1.0, sin(line * 3.14159));
+
+    let m = i32(floor(uv.x * u.out_size.x)) % 3;
+    var mask = vec3<f32>(0.8, 0.8, 0.8);
+    if (m == 0) { mask = vec3<f32>(1.0, 0.8, 0.8); }
+    else if (m == 1) { mask = vec3<f32>(0.8, 1.0, 0.8); }
+    else { mask = vec3<f32>(0.8, 0.8, 1.0); }
+    color = color * mask;
+
+    let vc = uv - 0.5;
+    color = color * mix(0.55, 1.0, clamp(1.0 - dot(vc, vc) * 0.9, 0.0, 1.0));
+
+    return min(color * 1.4, vec3<f32>(1.0, 1.0, 1.0));
+}
+
+// A proper CRT: curvature + tube shading, one texture tap.
+fn crt(uv0: vec2<f32>) -> vec4<f32> {
+    let uv = curve(uv0);
+    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0); // black bezel
+    }
+    let color = textureSample(tex, samp, uv).rgb;
+    return vec4<f32>(tube(color, uv), 1.0);
+}
+
+// Bright portion of a colour (soft threshold) — the part that "glows".
+fn bright(c: vec3<f32>) -> vec3<f32> {
+    return max(c - 0.30, vec3<f32>(0.0, 0.0, 0.0));
+}
+
+// Glow: the CRT tube plus a strong phosphor bloom — bright pixels bleed light
+// like a luminous CRT. Gathers bright neighbours at a few radii (~25 taps).
+fn fx_glow(uv0: vec2<f32>) -> vec4<f32> {
+    let uv = curve(uv0);
+    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+    }
+
+    let texel = 1.0 / TEX_SIZE;
+    var color = textureSample(tex, samp, uv).rgb;
+
+    var dirs = array<vec2<f32>, 8>(
+        vec2<f32>(1.0, 0.0), vec2<f32>(-1.0, 0.0),
+        vec2<f32>(0.0, 1.0), vec2<f32>(0.0, -1.0),
+        vec2<f32>(0.707, 0.707), vec2<f32>(-0.707, 0.707),
+        vec2<f32>(0.707, -0.707), vec2<f32>(-0.707, -0.707),
+    );
+    var glow = vec3<f32>(0.0, 0.0, 0.0);
+    for (var i: i32 = 0; i < 8; i = i + 1) {
+        let d = dirs[i] * texel;
+        glow = glow + bright(textureSample(tex, samp, uv + d * 1.5).rgb) * 0.65;
+        glow = glow + bright(textureSample(tex, samp, uv + d * 3.5).rgb) * 0.40;
+        glow = glow + bright(textureSample(tex, samp, uv + d * 7.0).rgb) * 0.25;
+    }
+    color = color + (glow / 8.0) * 2.2;
+
+    return vec4<f32>(tube(color, uv), 1.0);
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    if (u.effect == 3u) {
+        return crt(in.uv);
+    }
+    if (u.effect == 4u) {
+        return fx_glow(in.uv);
+    }
+
+    let src = in.uv * TEX_SIZE;
+    var color = textureSample(tex, samp, in.uv).rgb;
+
+    if (u.effect == 1u) {
+        color = epx(in.uv);
+    } else if (u.effect == 2u) {
+        // Smooth scanlines: bright at each source line's center, dark in the gaps,
+        // with brightness compensation so the picture doesn't dim overall.
+        let line = fract(src.y);
+        color = min(color * mix(0.5, 1.0, sin(line * 3.14159)) * 1.2, vec3<f32>(1.0, 1.0, 1.0));
+    }
+
+    return vec4<f32>(color, 1.0);
+}
+"#;

--- a/src/video_scaling.rs
+++ b/src/video_scaling.rs
@@ -280,35 +280,3 @@ pub fn apply_crt_effect(input: &[u8], width: u32, height: u32) -> Vec<u8> {
 
     output
 }
-/// Integer scaling - perfect pixel replication with no filtering
-/// Fast integer scaling - copies entire rows at once
-pub fn integer_scale(input: &[u8], width: u32, height: u32, scale: u32) -> Vec<u8> {
-    let w = width as usize;
-    let h = height as usize;
-    let s = scale as usize;
-    let out_w = w * s;
-    let out_h = h * s;
-    let mut output = vec![0u8; out_w * out_h * 4];
-
-    for y in 0..h {
-        let src_row_start = y * w * 4;
-
-        // Build one scaled row
-        let mut scaled_row = Vec::with_capacity(out_w * 4);
-        for x in 0..w {
-            let src_idx = src_row_start + x * 4;
-            // Repeat each pixel 'scale' times horizontally
-            for _ in 0..s {
-                scaled_row.extend_from_slice(&input[src_idx..src_idx + 4]);
-            }
-        }
-
-        // Copy the scaled row 'scale' times vertically
-        for dy in 0..s {
-            let out_row_start = (y * s + dy) * out_w * 4;
-            output[out_row_start..out_row_start + scaled_row.len()].copy_from_slice(&scaled_row);
-        }
-    }
-
-    output
-}

--- a/src/virtual_keyboard.rs
+++ b/src/virtual_keyboard.rs
@@ -1,0 +1,321 @@
+//! On-screen C64 keyboard. Clicking a key injects the corresponding PETSCII
+//! byte into the device's keyboard buffer (see `streaming::send_petscii`), so the
+//! user can enter any PETSCII character — including the SHIFT/C= graphics that a
+//! PC keyboard can't type. Key glyphs are drawn from the embedded C64 character
+//! ROM ([`crate::screenshot_api::embedded_char_rom`]), so they render correctly
+//! regardless of the host font.
+
+use iced::widget::image::Handle;
+use iced::widget::{button, column, container, image as iced_image, row, text, Space};
+use iced::{Alignment, Element, Length};
+
+use crate::streaming::StreamingMessage;
+
+/// Modifier ids carried by `StreamingMessage::VkModifier`.
+pub const MOD_SHIFT: u8 = 0;
+pub const MOD_COMMODORE: u8 = 1;
+pub const MOD_CTRL: u8 = 2;
+
+/// Convert a PETSCII code to its screen (character-ROM) code so we can look up
+/// the glyph. Standard C64 mapping.
+fn petscii_to_screencode(c: u8) -> u8 {
+    match c {
+        0..=31 => c + 128,
+        32..=63 => c,
+        64..=95 => c - 64,
+        96..=127 => c - 32,
+        128..=159 => c + 64,
+        160..=191 => c - 64,
+        192..=223 => c - 128,
+        224..=254 => c - 128,
+        255 => 94,
+    }
+}
+
+/// Pre-render the 128 uppercase/graphics glyphs (screen codes 0-127) as small
+/// white-on-transparent images. Built once when the keyboard is first shown.
+pub fn build_glyphs() -> Vec<Handle> {
+    const SCALE: usize = 3;
+    const SIZE: usize = 8 * SCALE;
+    let rom = crate::screenshot_api::embedded_char_rom();
+    let mut out = Vec::with_capacity(128);
+    for sc in 0..128usize {
+        let mut rgba = vec![0u8; SIZE * SIZE * 4];
+        for py in 0..8 {
+            let byte = rom[sc * 8 + py];
+            for px in 0..8 {
+                if byte & (0x80 >> px) != 0 {
+                    for dy in 0..SCALE {
+                        for dx in 0..SCALE {
+                            let x = px * SCALE + dx;
+                            let y = py * SCALE + dy;
+                            let i = (y * SIZE + x) * 4;
+                            rgba[i] = 235;
+                            rgba[i + 1] = 235;
+                            rgba[i + 2] = 240;
+                            rgba[i + 3] = 255;
+                        }
+                    }
+                }
+            }
+        }
+        out.push(Handle::from_rgba(SIZE as u32, SIZE as u32, rgba));
+    }
+    out
+}
+
+/// One key. `Ch` renders its glyph (which changes with the active modifiers);
+/// `Special` is a labelled key; `Mod` toggles a modifier; `Gap` is spacing.
+enum Key {
+    Ch {
+        normal: u8,
+        shift: u8,
+        comm: u8,
+    },
+    Special {
+        label: &'static str,
+        code: u8,
+        shift_code: u8,
+        width: f32,
+    },
+    Mod {
+        label: &'static str,
+        id: u8,
+        width: f32,
+    },
+    Gap(f32),
+}
+
+fn ch(normal: u8, shift: u8, comm: u8) -> Key {
+    Key::Ch {
+        normal,
+        shift,
+        comm,
+    }
+}
+
+/// The C64 keyboard layout, row by row.
+fn layout() -> Vec<Vec<Key>> {
+    let sp = |label, code, shift_code, width| Key::Special {
+        label,
+        code,
+        shift_code,
+        width,
+    };
+    vec![
+        vec![
+            ch(95, 95, 95), // <- left arrow
+            ch(49, 33, 49),
+            ch(50, 34, 50),
+            ch(51, 35, 51),
+            ch(52, 36, 52),
+            ch(53, 37, 53),
+            ch(54, 38, 54),
+            ch(55, 39, 55),
+            ch(56, 40, 56),
+            ch(57, 41, 57),
+            ch(48, 48, 48),
+            ch(43, 43, 166),  // +
+            ch(45, 45, 220),  // -
+            ch(92, 169, 168), // £
+            sp("CLR", 19, 147, 1.4),
+            sp("DEL", 20, 148, 1.4),
+        ],
+        vec![
+            Key::Mod {
+                label: "CTRL",
+                id: MOD_CTRL,
+                width: 1.5,
+            },
+            ch(81, 209, 171),
+            ch(87, 215, 179),
+            ch(69, 197, 177),
+            ch(82, 210, 178),
+            ch(84, 212, 163),
+            ch(89, 217, 183),
+            ch(85, 213, 184),
+            ch(73, 201, 162),
+            ch(79, 207, 185),
+            ch(80, 208, 175),
+            ch(64, 186, 164), // @
+            ch(42, 192, 223), // *
+            ch(94, 94, 94),   // up arrow
+        ],
+        vec![
+            sp("R/S", 3, 3, 1.5),
+            ch(65, 193, 176),
+            ch(83, 211, 174),
+            ch(68, 196, 172),
+            ch(70, 198, 187),
+            ch(71, 199, 165),
+            ch(72, 200, 180),
+            ch(74, 202, 181),
+            ch(75, 203, 161),
+            ch(76, 204, 182),
+            ch(58, 91, 58), // :
+            ch(59, 93, 59), // ;
+            ch(61, 61, 61), // =
+            sp("RETURN", 13, 13, 1.9),
+        ],
+        vec![
+            Key::Mod {
+                label: "C=",
+                id: MOD_COMMODORE,
+                width: 1.4,
+            },
+            Key::Mod {
+                label: "SHIFT",
+                id: MOD_SHIFT,
+                width: 1.6,
+            },
+            ch(90, 218, 173),
+            ch(88, 216, 189),
+            ch(67, 195, 188),
+            ch(86, 214, 190),
+            ch(66, 194, 191),
+            ch(78, 206, 170),
+            ch(77, 205, 167),
+            ch(44, 60, 44), // ,
+            ch(46, 62, 46), // .
+            ch(47, 63, 47), // /
+            Key::Mod {
+                label: "SHIFT",
+                id: MOD_SHIFT,
+                width: 1.6,
+            },
+            sp("↕", 17, 145, 1.2),
+            sp("↔", 29, 157, 1.2),
+        ],
+        vec![
+            sp("F1", 133, 137, 1.3),
+            sp("F3", 134, 138, 1.3),
+            sp("F5", 135, 139, 1.3),
+            sp("F7", 136, 140, 1.3),
+            Key::Gap(0.4),
+            sp("SPACE", 32, 32, 7.0),
+        ],
+    ]
+}
+
+/// Resolve a character key to the PETSCII byte it sends under the current
+/// modifier state.
+fn resolve(normal: u8, shift: u8, comm: u8, sh: bool, cm: bool, ct: bool) -> u8 {
+    if ct {
+        // CTRL sends the control-range code for letters; otherwise the normal byte.
+        if (65..=90).contains(&normal) {
+            normal & 0x1F
+        } else {
+            normal
+        }
+    } else if cm {
+        comm
+    } else if sh {
+        shift
+    } else {
+        normal
+    }
+}
+
+const KEY_UNIT: f32 = 26.0;
+const GLYPH_PX: f32 = 18.0;
+
+/// Build the keyboard element. `glyphs` are the pre-rendered screen-code glyphs.
+pub fn view<'a>(
+    glyphs: &[Handle],
+    shift: bool,
+    comm: bool,
+    ctrl: bool,
+    fs: &crate::styles::FontSizes,
+) -> Element<'a, StreamingMessage> {
+    let mut rows: Vec<Element<'a, StreamingMessage>> = Vec::new();
+    for r in layout() {
+        let mut cells: Vec<Element<'a, StreamingMessage>> = Vec::new();
+        for key in r {
+            match key {
+                Key::Ch {
+                    normal,
+                    shift: sh,
+                    comm: cm,
+                } => {
+                    let code = resolve(normal, sh, cm, shift, comm, ctrl);
+                    let scr = (petscii_to_screencode(code) & 0x7F) as usize;
+                    let glyph: Element<'a, StreamingMessage> = match glyphs.get(scr) {
+                        Some(h) => iced_image(h.clone())
+                            .width(Length::Fixed(GLYPH_PX))
+                            .height(Length::Fixed(GLYPH_PX))
+                            .into(),
+                        None => Space::new().into(),
+                    };
+                    cells.push(
+                        button(
+                            container(glyph)
+                                .center_x(Length::Fill)
+                                .center_y(Length::Fill),
+                        )
+                        .width(Length::Fixed(KEY_UNIT))
+                        .height(Length::Fixed(KEY_UNIT))
+                        .padding(2)
+                        .style(button::secondary)
+                        .on_press(StreamingMessage::VkSend(code))
+                        .into(),
+                    );
+                }
+                Key::Special {
+                    label,
+                    code,
+                    shift_code,
+                    width,
+                } => {
+                    let out = if shift { shift_code } else { code };
+                    cells.push(
+                        button(text(label).size(fs.tiny))
+                            .width(Length::Fixed(KEY_UNIT * width))
+                            .height(Length::Fixed(KEY_UNIT))
+                            .padding(2)
+                            .style(button::secondary)
+                            .on_press(StreamingMessage::VkSend(out))
+                            .into(),
+                    );
+                }
+                Key::Mod { label, id, width } => {
+                    let active = match id {
+                        MOD_SHIFT => shift,
+                        MOD_COMMODORE => comm,
+                        _ => ctrl,
+                    };
+                    cells.push(
+                        button(text(label).size(fs.tiny))
+                            .width(Length::Fixed(KEY_UNIT * width))
+                            .height(Length::Fixed(KEY_UNIT))
+                            .padding(2)
+                            .style(if active {
+                                button::primary
+                            } else {
+                                button::secondary
+                            })
+                            .on_press(StreamingMessage::VkModifier(id))
+                            .into(),
+                    );
+                }
+                Key::Gap(w) => {
+                    cells.push(Space::new().width(Length::Fixed(KEY_UNIT * w)).into());
+                }
+            }
+        }
+        rows.push(row(cells).spacing(3).align_y(Alignment::Center).into());
+    }
+
+    container(column(rows).spacing(3))
+        .padding(6)
+        .style(|_theme| container::Style {
+            background: Some(iced::Background::Color(iced::Color::from_rgba(
+                0.0, 0.0, 0.0, 0.72,
+            ))),
+            border: iced::Border {
+                radius: 8.0.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .into()
+}


### PR DESCRIPTION
Rework the video stream: GPU shader rendering (pixel-perfect integer scaling + CRT/Scanlines/Glow effects), Fifo-vsync smooth playback, and a 4 MB UDP receive buffer to stop frame drops.
Add a media-player overlay UI, an on-screen PETSCII keyboard (char-ROM glyphs, SHIFT/C= graphics), a bottom console, and persist the device address on Connect.